### PR TITLE
Avoid infinite loop in src/main.c

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -133,7 +133,8 @@ int main(int argc, char **argv){
     unsigned long long			main_pos = 0;
     int			tui = 0;		/// text user interface
     int			pui = 0;		/// progress mode(default text)
-    int                 next=1,next_int=1,next_max_count=7,next_count=7,i;
+    int                 next=1,next_int=1,next_max_count=7,next_count=7;
+    unsigned long long  i;
     unsigned long long  next_block_id;
     char*               cache_buffer;
     int                 nx_current=0;


### PR DESCRIPTION
image_hdr.totalblock may be unsigned 64 bits in size.

This patch can avoid infinite loop when use file system size is larger than 8TiB.
But I don't have very large file system, so I cannot test this patch.
