### PR TITLE
Suppress warnings reported by gcc for reiser4clone.h

### DIFF
--- a/src/reiser4clone.h
+++ b/src/reiser4clone.h
@@ -11,12 +11,6 @@
  * (at your option) any later version.
  */
 
-/// open device
-static void fs_open(char* device);
-
-/// close device
-static void fs_close();
-
 ///  readbitmap - read bitmap
 extern void readbitmap(char* device, image_head image_hdr, unsigned long* bitmap, int pui);
 


### PR DESCRIPTION
I fixed some warnings reported by gcc for reiser4clone.h.

```
reiser4clone.h:15:13: warning: ‘fs_open’ declared ‘static’ but never defined [-Wunused-function]
reiser4clone.h:18:13: warning: ‘fs_close’ declared ‘static’ but never defined [-Wunused-function]
```

```
$ ./confiture --enable-reiser4 CFLAGS="-std=gnu99 -Wall"
$ make 2> make.log
```
