### PR TITLE
Suppress warnings reported by gcc for btrfsclone.h.

### DIFF
--- a/src/btrfsclone.h
+++ b/src/btrfsclone.h
@@ -11,12 +11,6 @@
  * (at your option) any later version.
  */
 
-/// open device
-static void fs_open(char* device);
-
-/// close device
-static void fs_close();
-
 ///  readbitmap - read bitmap
 extern void readbitmap(char* device, image_head image_hdr, unsigned long* bitmap, int pui);
 


### PR DESCRIPTION
I fixed some warnings reported by gcc for btrfsclone.h.

```
btrfsclone.h:15: warning: 'fs_open' declared 'static' but never defined
btrfsclone.h:18: warning: 'fs_close' declared 'static' but never defined
```

```
$ ./confiture --enable-btrfs CFLAGS="-std=gnu99 -Wall"
$ make 2> make.log
```
