### PR TITLE
teach toolbox to use a relative path to generate src/version.h

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -93,7 +93,8 @@ fi
 ##
 if test "${action}" = "version"
 then
-  file="src/version.h"
+  scriptdir=`dirname "$0"`
+  file="$scriptdir/src/version.h"
   GIT_REPOSITORY=`git remote -v | grep partclone`
   GIT_REVISION=`git log -1 | grep commit | sed 's/commit //'`
   GIT_REVISION_UPSTREAM=`git log master -1 | grep commit | sed 's/commit //'`


### PR DESCRIPTION
When toolbox is called from the makefile, src/ is the working directory
and it fails to create src/version.h.
By using a path relative to its own location, it can be called from
anywhere in the project.

Signed-off-by: Patryck Rouleau pfrouleau@gmail.com
