### PR TITLE
toolbox-version: grab only the commit hash instead of the commit message

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -96,7 +96,7 @@ then
   scriptdir=`dirname "$0"`
   file="$scriptdir/src/version.h"
   GIT_REPOSITORY=`git remote -v | grep partclone`
-  GIT_REVISION=`git log -1 | grep commit | sed 's/commit //'`
+  GIT_REVISION=`git log -1 --format=%H`
   #GIT_REVISION_UPSTREAM=`git log master -1 | grep commit | sed 's/commit //'`
   git_ver="none"
 


### PR DESCRIPTION
This change prevent toolbox-version to keep too many lines when it updates
src/version.h, which was happening when the commit message contains the
word "commit".
