### PR TITLE
Fix the expectation of an extraneous checksum during restore/check in th...

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -595,7 +595,7 @@ int main(int argc, char **argv) {
 			if (bugcheck) {
 				read_size += blocks_read * CRC32_SIZE;
 			} else if (blocks_per_cs && blocks_read < buffer_capacity &&
-					(blocks_read % blocks_per_cs)) {
+					((copied + blocks_read) % blocks_per_cs)) {
 				/// it is the last read and there is a partial chunk at the end
 				log_mesg(1, 0, 0, debug, "# PARTIAL CHUNK\n");
 				read_size += cs_size;


### PR DESCRIPTION
Fix the expectation of an extraneous checksum during restore/check in the last read

When the last blocks are written and are less than cs_per_checksum, a last
checksum is written for them. During restore/check, we compute how many
bytes must be read (blocks+checksum).

However, there is an error in the condition that add one more checksum to
be read during the last read. That condition must takes into account the
number of blocks already copied.
