### PR TITLE
Fix get_exec_name(): when partclone in installed, there is no '/' in argv0

### DIFF
--- a/src/partclone.c
+++ b/src/partclone.c
@@ -312,8 +312,9 @@ static void save_program_name(const char* argv0) {
 	const char* last_slash = strrchr(argv0, '/');
 
 	if (last_slash != 0) {
-
 		exec_name = last_slash + 1;
+	} else {
+		exec_name = argv0;
 	}
 }
 


### PR DESCRIPTION
I forgot to test the case where partclone can be found through PATH and
in that case argv[0] does not contains a slash.

Signed-off-by: Patrick Rouleau pfrouleau@gmail.com
