### PR TITLE
Changes necessary to get building on Gentoo

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -120,7 +120,7 @@ AC_CHECK_HEADERS([reiserfs/reiserfs.h], ,
 )
 AC_CHECK_LIB([reiserfs], [reiserfs_fs_open], true,
     AC_MSG_ERROR([*** Reiserfs library (libreiserfs) not found]))
-AC_CHECK_LIB([dal], [file_dal_open], true,
+AC_CHECK_LIB([dal], [file_open], true,
     AC_MSG_ERROR([*** Reiserfs depend library (libdal) not found]))
 AC_MSG_CHECKING(version of libreiserfs)
 reiserfs_version=`gcc  $srcdir/src/deplib_version.c -o $srcdir/get_lib_version -lreiserfs -DREISERFS`

--- a/configure.ac
+++ b/configure.ac
@@ -56,7 +56,7 @@ AC_CHECK_LIB([pthread], [pthread_create], [], AC_MSG_ERROR([*** pthread library 
 ##ext2/3##
 AC_ARG_ENABLE(extfs,
 	AS_HELP_STRING(--enable-extfs,enable ext2/3/4 file system), 
-	enable_extfs=yes,
+	[],
 	enable_extfs=no
 )
 AM_CONDITIONAL(ENABLE_EXTFS, test "$enable_extfs" = yes)
@@ -81,7 +81,7 @@ fi
 ##XFS##
 AC_ARG_ENABLE(xfs,
 	AS_HELP_STRING(--enable-xfs,enable XFS file system), 
-	enable_xfs=yes,
+	[],
 	enable_xfs=no
 )
 AM_CONDITIONAL(ENABLE_XFS, test "$enable_xfs" = yes)
@@ -106,7 +106,7 @@ xfs_version="version unknown, suggest 3.1.1"
 ##reiserfs##
 AC_ARG_ENABLE(reiserfs,
 	AS_HELP_STRING(--enable-reiserfs,enable REISERFS 3.6/3.6 file system), 
-	enable_reiserfs=yes,
+	[],
 	enable_reiserfs=no
 )
 AM_CONDITIONAL(ENABLE_REISERFS, test "$enable_reiserfs" = yes)
@@ -160,7 +160,7 @@ fi
 ##reiser4##
 AC_ARG_ENABLE(reiser4,
 	AS_HELP_STRING(--enable-reiser4,enable Reiser4 file system), 
-	enable_reiser4=yes,
+	[],
 	enable_reiser4=no
 )
 AM_CONDITIONAL(ENABLE_REISER4, test "$enable_reiser4" = yes)
@@ -212,7 +212,7 @@ fi
 ##hfs plus##
 AC_ARG_ENABLE(hfsp,
 	AS_HELP_STRING(--enable-hfsp,enable HFS plus file system), 
-	enable_hfsp=yes,
+	[],
 	enable_hfsp=no
 )
 AM_CONDITIONAL(ENABLE_HFSP, test "$enable_hfsp" = yes)
@@ -240,7 +240,7 @@ fi
 ##exfat##
 AC_ARG_ENABLE(exfat,
 	AS_HELP_STRING(--enable-exfat,enable EXFAT file system), 
-	enable_exfat=yes,
+	[],
 	enable_exfat=no
 )
 AM_CONDITIONAL(ENABLE_EXFAT, test "$enable_exfat" = yes)
@@ -268,7 +268,7 @@ fi
 ##NTFS##
 AC_ARG_ENABLE(ntfs,
 	AS_HELP_STRING(--enable-ntfs,enable NTFS file system), 
-	enable_ntfs=yes,
+	[],
 	enable_ntfs=no
 )
 
@@ -342,7 +342,7 @@ fi
 ##UFS##
 AC_ARG_ENABLE(ufs,
 	AS_HELP_STRING(--enable-ufs,enable UFS(1/2) file system), 
-	enable_ufs=yes,
+	[],
 	enable_ufs=no
 )
 AM_CONDITIONAL(ENABLE_UFS, test "$enable_ufs" = yes)
@@ -362,7 +362,7 @@ fi
 ##VMFS##
 AC_ARG_ENABLE(vmfs,
 	AS_HELP_STRING(--enable-vmfs,enable vmfs file system), 
-	enable_vmfs=yes,
+	[],
 	enable_vmfs=no
 )
 AM_CONDITIONAL(ENABLE_VMFS, test "$enable_vmfs" = yes)
@@ -386,7 +386,7 @@ fi
 ##JFS##
 AC_ARG_ENABLE(jfs,
 	AS_HELP_STRING(--enable-jfs,enable jfs file system), 
-	enable_jfs=yes,
+	[],
 	enable_jfs=no
 )
 AM_CONDITIONAL(ENABLE_JFS, test "$enable_jfs" = yes)
@@ -409,7 +409,7 @@ fi
 ##btrfs##
 AC_ARG_ENABLE(btrfs,
 	AS_HELP_STRING(--enable-btrfs,enable btrfs file system), 
-	enable_btrfs=yes,
+	[],
 	enable_btrfs=no
 )
 AM_CONDITIONAL(ENABLE_BTRFS, test "$enable_btrfs" = yes)
@@ -427,7 +427,7 @@ fi
 ##minix##
 AC_ARG_ENABLE(minix,
 	AS_HELP_STRING(--enable-minix,enable minix file system), 
-	enable_minix=yes,
+	[],
 	enable_minix=no
 )
 AM_CONDITIONAL(ENABLE_MINIX, test "$enable_minix" = yes)
@@ -441,8 +441,7 @@ fi
 
 ##libncursesw##
 AC_ARG_ENABLE(ncursesw,
-	AS_HELP_STRING(--enable-ncursesw,enable TEXT User Interface), 
-	enable_ncursesw=yes,
+	AS_HELP_STRING(--enable-ncursesw,enable TEXT User Interface)
 )
 AM_CONDITIONAL(ENABLE_NCURSESW, test "$enable_ncursesw" = yes)
 
@@ -460,8 +459,7 @@ fi
 
 ##static linking##
 AC_ARG_ENABLE(static,
-	AS_HELP_STRING(--enable-static, enable static linking), 
-	enable_static=yes,
+	AS_HELP_STRING(--enable-static, enable static linking)
 )
 AM_CONDITIONAL(ENABLE_STATIC, test "$enable_static" = yes)
 
@@ -471,16 +469,14 @@ AM_CONDITIONAL(ENABLE_TINFO, test "$tinfo" = 1)
 
 ##memory tracing##
 AC_ARG_ENABLE(mtrace,
-	AS_HELP_STRING(--enable-mtrace, enable memory tracing), 
-	enable_memtrace=yes,
+	AS_HELP_STRING(--enable-mtrace, enable memory tracing)
 )
 AM_CONDITIONAL(ENABLE_MEMTRACE, test "$enable_memtrace" = yes)
 
 
 ##extra test
 AC_ARG_ENABLE(fs-test,
-        AS_HELP_STRING(--enable-fs-test, enable file system clone/restore test),
-        enable_fs_test=yes,
+        AS_HELP_STRING(--enable-fs-test, enable file system clone/restore test)
 )
 AM_CONDITIONAL(ENABLE_FS_TEST, test "$enable_fs_test" = yes)
 

--- a/src/reiserfsclone.c
+++ b/src/reiserfsclone.c
@@ -24,7 +24,7 @@
 #include <sys/types.h>
 #include <linux/types.h>
 #include <reiserfs/reiserfs.h>
-#include <dal/file_dal.h>
+#include <dal/file.h>
 #include "partclone.h"
 #include "reiserfsclone.h"
 #include "progress.h"
@@ -83,7 +83,7 @@ void read_bitmap(char* device, file_system_info fs_info, unsigned long* bitmap, 
 	
 	log_mesg(3, 0, 0, fs_opt.debug, "%s: block sb_block_count %llu\n", __FILE__, fs->super->s_v1.sb_block_count);
 	log_mesg(3, 0, 0, fs_opt.debug, "%s: block bitmap check %llu\n", __FILE__, blk);
-	if(reiserfs_tools_test_bit(blk, fs_bitmap->bm_map)){
+	if(reiserfs_tools_test_bit(blk, fs_bitmap->map)){
 	    bused++;
 	    pc_set_bit(blk, bitmap);
 	}else{

--- a/src/reiserfsclone.c
+++ b/src/reiserfsclone.c
@@ -36,7 +36,7 @@ reiserfs_fs_t	 *fs;
 /// open device
 static void fs_open(char* device){
 
-    if (!(dal = (dal_t*)file_dal_open(device, DEFAULT_BLOCK_SIZE, O_RDONLY))) {
+    if (!(dal = (dal_t*)file_open(device, DEFAULT_BLOCK_SIZE, O_RDONLY))) {
         log_mesg(0, 1, 1, fs_opt.debug, "%s: Couldn't create device abstraction for %s.\n", __FILE__, device);
     }
 
@@ -57,7 +57,7 @@ static void fs_open(char* device){
 static void fs_close(){
 
     reiserfs_fs_close(fs);
-    file_dal_close(dal);
+    file_close(dal);
 
 }
 


### PR DESCRIPTION
* Gentoo's build system will pass --disable-foo for options that it wants disabled, so fix it so that --disable-foo options actually disable instead of enabling things.
* The version of progsreiserfs that is currently in Gentoo's package tree has some header, function, and struct member name changes.  One of the patches was written by someone else, the URL that I found it at is http://linamh.disconnected-by-peer.at/linamh/browser/sys-block/partclone/files/partclone-0.2.36-progsreiserfs-0.3.1-1.patch?rev=ea577defdd55fc399aefa7caba0dbccf8e66258d

See also my update to a bug trying to get partclone included in Gentoo's package system:
https://bugs.gentoo.org/show_bug.cgi?id=486518