### PR TITLE
Fix missing includes

### DIFF
--- a/src/deplib_version.c
+++ b/src/deplib_version.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <string.h> // for strcmp()
 
 #ifdef EXTFS
     #include <ext2fs/ext2fs.h>


### PR DESCRIPTION
When building with gcc5, string.h is no longer implicit included and the
source must declare the includes.

Otherwise, the build 'warns' about this error (which can have quite bad
results):

[   26s] ./src/deplib_version.c:31:9: warning: implicit declaration of
function 'strcmp' [-Wimplicit-function-declaration]
[   26s]      if (strcmp(libfs, "ntfs") == 0){

Spotted by openSUSE Build Root Policy verification:
[   40s] E: partclone implicit-fortify-decl ./src/deplib_version.c:31