### PR TITLE
f2fs: remove unused variables

### DIFF
--- a/src/f2fsclone.c
+++ b/src/f2fsclone.c
@@ -66,7 +66,6 @@ extern void read_bitmap(char* device, file_system_info fs_info, unsigned long* b
     off_t block = 0;;
     int start = 0;
     int bit_size = 1;
-    unsigned long long bused, bfree;
 
     fs_open(device);
     struct f2fs_super_block *sb = F2FS_RAW_SUPER(sbi);
@@ -82,7 +81,6 @@ extern void read_bitmap(char* device, file_system_info fs_info, unsigned long* b
     for ( block = 0; block <= sb->main_blkaddr ; block++ ){
     
 	    log_mesg(2, 0, 0, fs_opt.debug, "%s: test SIT bitmap is 0x1. blk_addr[0x%x] %i\n", __FILE__, block, block);
-	    bused++;
 	    pc_set_bit(block, bitmap);
 	    log_mesg(3, 0, 0, fs_opt.debug, "%s: bitmap is used %llu", __FILE__, block);
     }
@@ -92,11 +90,9 @@ extern void read_bitmap(char* device, file_system_info fs_info, unsigned long* b
 	if (f2fs_test_bit(BLKOFF_FROM_MAIN(sbi, block), fsck->sit_area_bitmap) == 0x0) {
 	    log_mesg(2, 0, 0, fs_opt.debug, "%s: test SIT bitmap is 0x0. blk_addr[0x%x] %i\n", __FILE__, block, block);
 	    pc_clear_bit(block, bitmap);
-	    bfree++;
 	    log_mesg(3, 0, 0, fs_opt.debug, "%s: bitmap is free %llu", __FILE__, block);
 	}else{
 	    log_mesg(2, 0, 0, fs_opt.debug, "%s: test SIT bitmap is 0x1. blk_addr[0x%x] %i\n", __FILE__, block, block);
-	    bused++;
 	    pc_set_bit(block, bitmap);
 	    log_mesg(3, 0, 0, fs_opt.debug, "%s: bitmap is used %llu", __FILE__, block);
 


### PR DESCRIPTION
This commit fixes following the errors which are reported cppcheck.

  src/f2fsclone.c:88]: (error) Uninitialized variable: bused
  src/f2fsclone.c:98]: (error) Uninitialized variable: bfree