### PR TITLE
partclone: fix memory leak

### DIFF
--- a/src/partclone.c
+++ b/src/partclone.c
@@ -1342,8 +1342,10 @@ int check_mount(const char* device, char* mount_p){
 		return -1;
 	}
 
-	if (!realpath(device, real_file))
+	if (!realpath(device, real_file)) {
+		free(real_fsname);
 		return -1;
+	}
 
 	if ((f = setmntent(MOUNTED, "r")) == 0) {
 		free(real_file);


### PR DESCRIPTION
This commit fixes following the error which is reported by cppcheck:

  src/partclone.c:803]: (error) Memory leak: real_fsname