### PR TITLE
Fix sign-compare warnings in xfsclone.c

### DIFF
--- a/src/xfsclone.c
+++ b/src/xfsclone.c
@@ -178,7 +178,7 @@ scan_freelist(
 	xfs_agnumber_t	seqno = be32_to_cpu(agf->agf_seqno);
 	xfs_agfl_t	*agfl;
 	xfs_agblock_t	bno;
-	int		i;
+	unsigned int	i;
 	__be32		*agfl_bno;
 	struct xfs_buf	*bp;
 	const struct xfs_buf_ops *ops = NULL;


### PR DESCRIPTION
  xfsclone.c:211:9: warning: comparison between signed and unsigned [-Wsign-compare]
     if (i == be32_to_cpu(agf->agf_fllast))
         ^
  xfsclone.c:213:11: warning: comparison between signed and unsigned [-Wsign-compare]
     if (++i == XFS_AGFL_SIZE(mp))