### PR TITLE
Use "which" if "locate" doesn't exist (e.g. in build environments)

### DIFF
--- a/tests/_common
+++ b/tests/_common
@@ -91,7 +91,12 @@ _findmkfs(){
 	;;
     esac
 
-    mkfs_path=$(locate mkfs.$fs|grep sbin|head -n 1)
+    locate_path=$(type -P locate)
+    if [ -z $locate_path ]; then
+        locate_path="which"
+    fi
+
+    mkfs_path=$($locate_path mkfs.$fs|grep sbin|head -n 1)
     if [ -z $mkfs_path ]; then
 	echo  >&2 "can't find mkfs.$fs"
 	exit 1


### PR DESCRIPTION
In the average Fedora build environment, `locate` does not exist in `$PATH` (aside of that, it would require an `updatedb` before which is IMHO a waste of resources, given the whole filesystem is indexed). Thus use `which` if `locate` does not exist, this is backwards compatible, but serves build environments as well.