### PR TITLE
Distinguish between (non-)interactive shell (courtesy of "UNIX F.A.Q.", 1993)

### DIFF
--- a/tests/_common
+++ b/tests/_common
@@ -55,7 +55,7 @@ _check_return_code(){
 }
 
 _ptlbreak(){
-    if [ $break_debug -ne 0 ];then
+    if [[ $break_debug -ne 0 && $- = *"i"* ]];then
 
 	echo "continue test process(Y/n)? default yes"
 	read con


### PR DESCRIPTION
The average buildsystem (such as the Fedora one) does not have an interactive shell, thus waiting for interactive input is not a good idea. Simply skip the question on non-interactive shells.