### PR TITLE
Honor $RPM_ARCH alternatively to dpkg-architecture(1) for build-time architecture detection

### DIFF
--- a/fail-mbr/compile-mbr.sh
+++ b/fail-mbr/compile-mbr.sh
@@ -1,5 +1,5 @@
 ############### compiles source file for x86 architectures ##################
-if dpkg-architecture -e amd64 || dpkg-architecture -e i386; then
+if dpkg-architecture -e amd64 || dpkg-architecture -e i386 || [ "$RPM_ARCH" = "x86_64" ] || [ "$RPM_ARCH" = "i386" ]; then
    # compile the file fail-mbr.bin
     #echo -n "Compiling: fail-mbr.S -> fail-mbr.o -> "
     #gcc -Wall -Werror -m32 -nostdlib -static -o fail-mbr.o fail-mbr.S


### PR DESCRIPTION
By default only `dpkg-architecture` is queried – which poorly fails on RPM-based architectures, such as Fedora or CentOS. The patch additionally adds `$RPM_ARCH` in the same manner like existing `dpkg-architecture` is being used.