### PR TITLE
fix small bugs in btrfs support

### DIFF
--- a/src/btrfs/volumes.c
+++ b/src/btrfs/volumes.c
@@ -165,7 +165,7 @@ again:
 	while (!list_empty(&fs_devices->devices)) {
 		device = list_entry(fs_devices->devices.next,
 				    struct btrfs_device, dev_list);
-        assert(device == NULL);
+        assert(device != NULL);
 		if (device->fd != -1) {
 			fsync(device->fd);
 			if (posix_fadvise(device->fd, 0, 0, POSIX_FADV_DONTNEED))

--- a/src/btrfsclone.c
+++ b/src/btrfsclone.c
@@ -341,6 +341,8 @@ void read_bitmap(char* device, file_system_info fs_info, unsigned long* bitmap, 
     struct btrfs_root_item ri;
     int slot;
 
+    total_block = fs_info.totalblock;
+
     fs_open(device);
     dev_size = fs_info.device_size;
     block_size  = btrfs_super_nodesize(info->super_copy);

--- a/src/main.c
+++ b/src/main.c
@@ -67,7 +67,8 @@ int main(int argc, char **argv) {
 	int			r_size, w_size;		/// read and write size
 	unsigned		cs_size = 0;		/// checksum_size
 	int			cs_reseed = 1;
-	int			start, stop;		/// start, range, stop number for progress bar
+	int			start;
+	unsigned long long      stop;		/// start, range, stop number for progress bar
 	unsigned long *bitmap = NULL;		/// the point for bitmap data
 	int			debug = 0;		/// debug level
 	int			tui = 0;		/// text user interface


### PR DESCRIPTION
Bugs were minor, but prevent from cloning a btrfs partition:
- bad assertion check;
- missing variable initialization.

These fixes seem sufficient at least in my case.

I don't know how an additional change can be excluded from the pull request: it fails to fix the issue with the progress bar. Though, it fixes a type that seems incorrect in main.c.