### PR TITLE
Support compressed cloned images

### DIFF
--- a/docs/partclone.8
+++ b/docs/partclone.8
@@ -97,6 +97,11 @@ Overwrite FILE, overwriting if exists\&.
 Save partition to the special image format\&.
 .RE
 .PP
+\fB\-x\fR, \fB\-\-compresscmd \fR\fB\fICMD\fR\fR
+.RS 4
+Execute CMD in a write-only pipe to compress the output image\&. Applicable to cloning\&. The output file is always overwritten\&.
+.RE
+.PP
 \fB\-r\fR, \fB\-\-restore\fR
 .RS 4
 Restore partition from the special image format\&.

--- a/src/main.c
+++ b/src/main.c
@@ -999,7 +999,7 @@ int main(int argc, char **argv) {
 	close(dfr);
 	/// close target
 	if (dfw != -1)
-		close(dfw);
+		close_target(dfw);
 	/// free bitmp
 	free(bitmap);
 	close_pui(pui);

--- a/src/partclone.c
+++ b/src/partclone.c
@@ -1648,6 +1648,8 @@ int close_target(int dfw) {
 
 	if (compress_pipe)
 		ret = pclose(compress_pipe);
+	else
+		ret = close(dfw);
 	compress_pipe = NULL;
 	return ret;
 }

--- a/src/partclone.c
+++ b/src/partclone.c
@@ -217,6 +217,7 @@ void usage(void) {
 #ifndef RESTORE
 #ifndef DD
 		"    -c,  --clone            Save to the special image format\n"
+		"    -x,  --compresscmd CMD  Start CMD as an output pipe to compress the cloned image\n"
 		"    -r,  --restore          Restore from the special image format\n"
 		"    -b,  --dev-to-dev       Local device to device copy mode\n"
 #endif
@@ -316,7 +317,7 @@ void parse_options(int argc, char **argv, cmd_opt* opt) {
 #elif DD
 	static const char *sopt = "-hvd::L:o:O:s:f:CFINiqWBz:E:n:";
 #else
-	static const char *sopt = "-hvd::L:cbrDo:O:s:f:RCFINiqWBz:E:a:k:Kn:T";
+	static const char *sopt = "-hvd::L:cx:brDo:O:s:f:RCFINiqWBz:E:a:k:Kn:T";
 #endif
 
 	static const struct option lopt[] = {
@@ -338,6 +339,7 @@ void parse_options(int argc, char **argv, cmd_opt* opt) {
 #ifndef RESTORE
 #ifndef DD
 		{ "clone",		no_argument,		NULL,   'c' },
+		{ "compresscmd",	required_argument,	NULL,	'x' },
 		{ "restore",		no_argument,		NULL,   'r' },
 		{ "dev-to-dev",		no_argument,		NULL,   'b' },
 #endif
@@ -455,6 +457,9 @@ void parse_options(int argc, char **argv, cmd_opt* opt) {
 			case 'c':
 				opt->clone++;
 				mode=1;
+				break;
+			case 'x':
+				opt->compresscmd = optarg;
 				break;
 			case 'r':
 				opt->restore++;
@@ -1536,6 +1541,8 @@ int open_source(char* source, cmd_opt* opt) {
 	return ret;
 }
 
+static FILE *compress_pipe = NULL;
+
 int open_target(char* target, cmd_opt* opt) {
 	int ret = 0;
 	int debug = opt->debug;
@@ -1563,7 +1570,16 @@ int open_target(char* target, cmd_opt* opt) {
 	}
 
 	if ((opt->clone || opt->domain || (ddd_block_device == 0)) && (opt->blockfile == 0)) {
-		if (strcmp(target, "-") == 0) {
+		if (opt->compresscmd) {
+			int strsz = strlen(opt->compresscmd) + strlen(target) + 4;
+			char *compresscmd = malloc(strsz);
+
+			sprintf(compresscmd, "%s >%s", opt->compresscmd, target);
+			compress_pipe = popen(compresscmd, "w");
+			free(compresscmd);
+			if ((ret = (compress_pipe ? fileno(compress_pipe) : -1)) == -1)
+				log_mesg(0, 1, 1, debug, "clone: popen (%s >%s) error\n", opt->compresscmd, target);
+		} else if (strcmp(target, "-") == 0) {
 			if ((ret = fileno(stdout)) == -1)
 				log_mesg(0, 1, 1, debug, "clone: open %s(stdout) error\n", target);
 		} else {
@@ -1626,6 +1642,16 @@ int open_target(char* target, cmd_opt* opt) {
 
 	return ret;
 }
+
+int close_target(int dfw) {
+	int ret = 0;
+
+	if (compress_pipe)
+		ret = pclose(compress_pipe);
+	compress_pipe = NULL;
+	return ret;
+}
+
 int write_block_file(char* target, char *buf, unsigned long long count, unsigned long long offset, cmd_opt* opt){
 	long long int i;
 	int debug = opt->debug;
@@ -1770,9 +1796,12 @@ void print_partclone_info(cmd_opt opt) {
 	log_mesg(0, 0, 1, debug, _("Partclone v%s http://partclone.org\n"), VERSION);
 	if (opt.chkimg)
 		log_mesg(0, 0, 1, debug, _("Starting to check image (%s)\n"), opt.source);	
-	else if (opt.clone)
-		log_mesg(0, 0, 1, debug, _("Starting to clone device (%s) to image (%s)\n"), opt.source, opt.target);	
-	else if(opt.restore){
+	else if (opt.clone) {
+		if (opt.compresscmd)
+			log_mesg(0, 0, 1, debug, _("Starting to clone device (%s) to compressed image (%s)\n"), opt.source, opt.target);
+		else
+			log_mesg(0, 0, 1, debug, _("Starting to clone device (%s) to image (%s)\n"), opt.source, opt.target);
+	} else if(opt.restore){
 	        if (opt.blockfile)
 		    log_mesg(0, 0, 1, debug, _("Starting to restore image (%s) to block files (%s)\n"), opt.source, opt.target);
 		else

--- a/src/partclone.h
+++ b/src/partclone.h
@@ -100,6 +100,7 @@ struct cmd_opt
     int debug;
     char* source;
     char* target;
+    char* compresscmd;
     char* logfile;
     char note[NOTE_SIZE];
     int overwrite;
@@ -314,6 +315,7 @@ extern void read_bitmap(char* device, file_system_info fs_info, unsigned long* b
  */
 extern int open_source(char* source, cmd_opt* opt);
 extern int open_target(char* target, cmd_opt* opt);
+extern int close_target(int dfw);
 
 /// check partition size
 extern int check_size(int* ret, unsigned long long size);

--- a/src/readblock.c
+++ b/src/readblock.c
@@ -198,7 +198,7 @@ int main(int argc, char **argv){
 	log_mesg(0, 1, 1, opt.debug, "source seek ERROR:%s\n", strerror(errno));
     r_size = read_all(&dfr, read_buffer, fs_info.block_size, &opt);
     w_size = write_all(&dfw, read_buffer, fs_info.block_size, &opt);
-    close(dfw);
+    close_target(dfw);
 
     close(dfr);     /// close source
     free(bitmap);   /// free bitmap


### PR DESCRIPTION
The ncurses mode obviously conflicts with writing the cloned image
to stdout. Piping the image to a command to compress it while in
ncurses mode is unusable because of this.

Fix it by adding a new option -x / --compresscmd CMD that is
executed in a write-only pipe internally by partclone.

Signed-off-by: Böszörményi Zoltán <zboszor@pr.hu>