### PR TITLE
Create Torrent Info while converting image to BT format

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,6 +1,6 @@
 AUTOMAKE_OPTIONS = subdir-objects
 AM_CPPFLAGS = -DLOCALEDIR=\"$(localedir)\" -D_FILE_OFFSET_BITS=64
-LDADD = $(LIBINTL)
+LDADD = $(LIBINTL) -lcrypto
 sbin_PROGRAMS=partclone.info partclone.dd partclone.restore partclone.chkimg partclone.imager #partclone.imgfuse #partclone.block
 TOOLBOX = srcdir=$(top_srcdir) builddir=$(top_builddir) $(top_srcdir)/toolbox
 
@@ -60,21 +60,21 @@ if ENABLE_EXTFS
 sbin_PROGRAMS += partclone.extfs
 partclone_extfs_SOURCES=$(main_files) extfsclone.c extfsclone.h
 partclone_extfs_CFLAGS=-DEXTFS
-partclone_extfs_LDADD=-lext2fs -lcom_err -lpthread
+partclone_extfs_LDADD=-lext2fs -lcom_err -lpthread -lcrypto
 endif
 
 if ENABLE_REISERFS
 sbin_PROGRAMS += partclone.reiserfs
 partclone_reiserfs_SOURCES=$(main_files) reiserfsclone.c reiserfsclone.h
 partclone_reiserfs_CFLAGS=-DREISERFS
-partclone_reiserfs_LDADD=-lreiserfs -ldal
+partclone_reiserfs_LDADD=-lreiserfs -ldal -lcrypto
 endif
 
 if ENABLE_REISER4
 sbin_PROGRAMS += partclone.reiser4
 partclone_reiser4_SOURCES=$(main_files) reiser4clone.c reiser4clone.h
 partclone_reiser4_CFLAGS=-DREISER4
-partclone_reiser4_LDADD=-lreiser4 -laal
+partclone_reiser4_LDADD=-lreiser4 -laal -lcrypto
 endif
 
 if ENABLE_HFSP
@@ -87,7 +87,7 @@ if ENABLE_XFS
 sbin_PROGRAMS += partclone.xfs
 partclone_xfs_SOURCES=$(main_files) xfsclone.c xfsclone.h $(XFS_SOURCE)
 partclone_xfs_CFLAGS=-Ixfs/include -Ixfs/libxfs/ -Ixfs/include/xfs/ -DXFS -D_GNU_SOURCE -DNDEBUG  $(UUID_CFLAGS) 
-partclone_xfs_LDADD=-lrt -lpthread -luuid
+partclone_xfs_LDADD=-lrt -lpthread -luuid -lcrypto
 endif
 
 if ENABLE_EXFAT
@@ -100,14 +100,14 @@ if ENABLE_F2FS
 sbin_PROGRAMS += partclone.f2fs
 partclone_f2fs_SOURCES=$(main_files) f2fsclone.c f2fsclone.h $(F2FS_SOURCE)
 partclone_f2fs_CFLAGS=-DF2FS
-partclone_f2fs_LDADD=-luuid
+partclone_f2fs_LDADD=-luuid -lcrypto
 endif
 
 if ENABLE_NILFS2
 sbin_PROGRAMS += partclone.nilfs2
 partclone_nilfs2_SOURCES=$(main_files) nilfsclone.c nilfsclone.h
 partclone_nilfs2_CFLAGS=-DNILFS
-partclone_nilfs2_LDADD=-lnilfs
+partclone_nilfs2_LDADD=-lnilfs -lcrypto
 endif
 
 if ENABLE_FAT
@@ -123,10 +123,10 @@ sbin_PROGRAMS += partclone.ntfs
 partclone_ntfs_SOURCES=$(main_files) ntfsclone-ng.c ntfsclone-ng.h
 if ENABLE_NTFS_3G
 partclone_ntfs_CFLAGS=-DNTFS3G
-partclone_ntfs_LDADD=-lntfs-3g
+partclone_ntfs_LDADD=-lntfs-3g -lcrypto
 else
 partclone_ntfs_CFLAGS=-DNTFS
-partclone_ntfs_LDADD=-lntfs
+partclone_ntfs_LDADD=-lntfs -lcrypto
 endif
 endif
 
@@ -134,24 +134,24 @@ if ENABLE_UFS
 sbin_PROGRAMS += partclone.ufs
 partclone_ufs_SOURCES=$(main_files) ufsclone.c ufsclone.h
 partclone_ufs_CFLAGS=-DUFS -D_GNU_SOURCE
-partclone_ufs_LDADD=-lufs -lbsd
+partclone_ufs_LDADD=-lufs -lbsd -lcrypto
 endif
 
 if ENABLE_VMFS
 sbin_PROGRAMS += partclone.vmfs
 partclone_vmfs_SOURCES=$(main_files) vmfsclone.c vmfsclone.h
 partclone_vmfs_CFLAGS=-DVMFS -D_GNU_SOURCE $(UUID_CFLAGS)
-partclone_vmfs_LDADD=-lvmfs -luuid
+partclone_vmfs_LDADD=-lvmfs -luuid -lcrypto
 
 sbin_PROGRAMS += partclone.vmfs5
 partclone_vmfs5_SOURCES=$(main_files) vmfs5clone.c vmfsclone.h
 partclone_vmfs5_CFLAGS=-DVMFS -D_GNU_SOURCE $(UUID_CFLAGS)
-partclone_vmfs5_LDADD=-lvmfs -luuid
+partclone_vmfs5_LDADD=-lvmfs -luuid -lcrypto
 
 sbin_PROGRAMS += partclone.fstype
 partclone_fstype_SOURCES=fstype.c
 partclone_fstype_CFLAGS=-DVMFS -D_GNU_SOURCE $(UUID_CFLAGS)
-partclone_fstype_LDADD=-lvmfs -luuid
+partclone_fstype_LDADD=-lvmfs -luuid -lcrypto
 
 endif
 
@@ -160,14 +160,14 @@ sbin_PROGRAMS += partclone.jfs
 #partclone_jfs_SOURCES=$(main_files) jfs_devices.c jfs_devices.h jfsclone.c jfsclone.h
 partclone_jfs_SOURCES=$(main_files) jfsclone.c jfsclone.h
 partclone_jfs_CFLAGS=-DJFS
-partclone_jfs_LDADD=-luuid -ljfs
+partclone_jfs_LDADD=-luuid -ljfs -lcrypto
 endif
 
 if ENABLE_BTRFS
 sbin_PROGRAMS += partclone.btrfs
 partclone_btrfs_SOURCES=$(main_files) btrfsclone.c btrfsclone.h $(BTRFS_SOURCE)
 partclone_btrfs_CFLAGS=-DBTRFS -DBTRFS_FLAT_INCLUDES -D_XOPEN_SOURCE=700 -D_GNU_SOURCE
-partclone_btrfs_LDADD=-luuid -lblkid 
+partclone_btrfs_LDADD=-luuid -lblkid -lcrypto
 endif
 
 if ENABLE_MINIX
@@ -179,9 +179,9 @@ endif
 if ENABLE_FUSE
 sbin_PROGRAMS+=partclone.imgfuse
 partclone_imgfuse_SOURCES=fuseimg.c partclone.c checksum.c partclone.h fs_common.h checksum.h
-partclone_imgfuse_LDADD=-lfuse
+partclone_imgfuse_LDADD=-lfuse -lcrypto
 if ENABLE_STATIC
-partclone_imgfuse_LDADD+=-ldl
+partclone_imgfuse_LDADD+=-ldl -lcrypto
 endif
 endif
 

--- a/src/main.c
+++ b/src/main.c
@@ -27,7 +27,10 @@
 #include <unistd.h>
 #include <pthread.h>
 #include <assert.h>
-#include<dirent.h>
+#include <dirent.h>
+
+// SHA1 for torrent info
+#include <openssl/sha.h>
 
 /**
  * progress.h - only for progress bar
@@ -571,6 +574,13 @@ int main(int argc, char **argv) {
 		char *read_buffer, *write_buffer;
 		unsigned long long blocks_used_fix = 0, test_block = 0;
 
+		// SHA1 for torrent info
+		SHA_CTX ctx;
+		unsigned char hash[SHA_DIGEST_LENGTH + 1] = {'\0'};
+		unsigned long long sha_length = 0;
+		const unsigned long long BT_PIECE_SIZE = 16ULL * 1024 * 1024;
+		int tinfo = -1;
+
 		log_mesg(1, 0, 0, debug, "#\nBuffer capacity = %u, Blocks per cs = %u\n#\n", buffer_capacity, blocks_per_cs);
 
 		// fix some super block record incorrect
@@ -610,6 +620,15 @@ int main(int argc, char **argv) {
 		blocks_in_cs = 0;
 		if (!opt.ignore_crc)
 			init_checksum(img_opt.checksum_mode, checksum, debug);
+
+		// init SHA1 for torrent info
+		if (opt.blockfile == 1) {
+			char torrent_name[PATH_MAX + 1] = {'\0'};
+			sprintf(torrent_name,"%s/torrent.info", target);
+			tinfo = open(torrent_name, O_RDWR | O_CREAT, S_IRUSR | S_IWUSR);
+
+			SHA1_Init(&ctx);
+		}
 
 		block_id = 0;
 		do {
@@ -727,6 +746,51 @@ int main(int argc, char **argv) {
 				// write blocks
 				if (blocks_write > 0) {
 				        if (opt.blockfile == 1){
+					    // SHA1 for torrent info
+					    // Not always bigger or smaller than 16MB
+					    
+					    // first we write out block_id * block_size for filename
+					    // because when calling write_block_file
+					    // we will create a new file to describe a continuous block (or buffer is full)
+					    // and never write to same file again
+					    dprintf(tinfo, "offset: %032llx\n", block_id * block_size);
+					    dprintf(tinfo, "length: %032llx\n", blocks_write * block_size);
+
+					    // every BT piece is 16MiB
+					    unsigned long long sha_remain_length = BT_PIECE_SIZE - sha_length;
+					    unsigned long long buffer_remain_length = blocks_write * block_size;
+					    unsigned long long buffer_offset = 0;
+					    while (buffer_remain_length > 0) {
+					        sha_remain_length = BT_PIECE_SIZE - sha_length;
+						if (sha_remain_length <= 0) {
+						    // finish a piece
+						    SHA1_Final(hash, &ctx);
+						    dprintf(tinfo, "sha1: ");
+						    for (int x = 0; x < SHA_DIGEST_LENGTH; x++) {
+						        dprintf(tinfo, "%02x", hash[x]);
+						    }
+						    dprintf(tinfo, "\n");
+						    // start for next piece;
+						    SHA1_Init(&ctx);
+						    sha_length = 0;
+					            sha_remain_length = BT_PIECE_SIZE;
+						}
+						if (buffer_remain_length <= 0) {
+						    break;
+						}
+						else if (sha_remain_length > buffer_remain_length) {
+						    SHA1_Update(&ctx, write_buffer + blocks_written * block_size + buffer_offset, buffer_remain_length);
+						    sha_length += buffer_remain_length;
+						    break;
+						}
+						else {
+						    SHA1_Update(&ctx, write_buffer + blocks_written * block_size + buffer_offset, sha_remain_length);
+						    buffer_offset += sha_remain_length;
+						    buffer_remain_length -= sha_remain_length;
+						    sha_length += sha_remain_length;
+						}
+					    }
+
 					    w_size = write_block_file(target, write_buffer + blocks_written * block_size,
 						    blocks_write * block_size, (block_id*block_size), &opt);
 					}else{
@@ -748,6 +812,19 @@ int main(int argc, char **argv) {
 			} while (blocks_written < blocks_read);
 
 		} while(1);
+
+		// finish SHA1 for torrent info
+		if (opt.blockfile == 1) {
+			if (sha_length) {
+				SHA1_Final(hash, &ctx);
+				dprintf(tinfo, "sha1: ");
+				for (int x = 0; x < SHA_DIGEST_LENGTH; x++) {
+					dprintf(tinfo, "%02x", hash[x]);
+				}
+				dprintf(tinfo, "\n");
+			}
+		}
+
 		free(write_buffer);
 		free(read_buffer);
 


### PR DESCRIPTION
We can create torrent info while converting image to BT format.
`torrent.info` will place at `<target dir>`
Use [partclone_create_torrent.py](https://github.com/tjjh89017/ezio/blob/master/utils/partclone_create_torrent.py) to make "true" torrent.
```
cat torrent.info | ./partclone_create_torrent.py
ls -l a.torrent # the torrent we need
```

https://github.com/tjjh89017/ezio/blob/master/utils/partclone_create_torrent.py#L25
**IMPORTNAT**
L25 `a/` will be the directory name for files
Change it to what you what, otherwise EZIO may not find files to seed.
