### PR TITLE
src/main.c: add limits.h include for PATH_MAX

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -28,6 +28,7 @@
 #include <pthread.h>
 #include <assert.h>
 #include <dirent.h>
+#include <limits.h>
 
 // SHA1 for torrent info
 #include <openssl/sha.h>


### PR DESCRIPTION
fixes compilation with musl libc

Error message

[Full log on travis](https://travis-ci.org/void-linux/void-packages/jobs/447602285)

```
cc -DHAVE_CONFIG_H -I. -I..  -DLOCALEDIR=\"/usr/share/locale\" -D_FILE_OFFSET_BITS=64  -DDD -D_FORTIFY_SOURCE=2 -mtune=generic -O2 -pipe  -DBTRFS_DISABLE_BACKTRACE  -Wall -MT partclone_dd-main.o -MD -MP -MF .deps/partclone_dd-main.Tpo -c -o partclone_dd-main.o `test -f 'main.c' || echo './'`main.c
main.c: In function 'main':
main.c:625:22: error: 'PATH_MAX' undeclared (first use in this function); did you mean 'INT8_MAX'?
    char torrent_name[PATH_MAX + 1] = {'\0'};
                      ^~~~~~~~
                      INT8_MAX
```