### PR TITLE
Generate BT info directly

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -41,7 +41,7 @@ endif
 version.h: FORCE
 	$(TOOLBOX) --update-version
 
-main_files=main.c partclone.c progress.c checksum.c partclone.h progress.h gettext.h checksum.h
+main_files=main.c partclone.c progress.c checksum.c torrent_helper.c partclone.h progress.h gettext.h checksum.h torrent_helper.h
 
 partclone_info_SOURCES=info.c partclone.c checksum.c partclone.h fs_common.h checksum.h
 partclone_restore_SOURCES=$(main_files) ddclone.c ddclone.h

--- a/src/main.c
+++ b/src/main.c
@@ -452,7 +452,7 @@ int main(int argc, char **argv) {
 		if (opt.blockfile == 1) {
 			char torrent_name[PATH_MAX + 1] = {'\0'};
 			sprintf(torrent_name,"%s/torrent.info", target);
-			tinfo = open(torrent_name, O_RDWR | O_CREAT, S_IRUSR | S_IWUSR);
+			tinfo = open(torrent_name, O_RDWR | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR);
 
 			torrent_init(&torrent, tinfo);
 		}

--- a/src/main.c
+++ b/src/main.c
@@ -540,7 +540,11 @@ int main(int argc, char **argv) {
 
 				torrent_update(&torrent, read_buffer, blocks_read * block_size);
 
-				w_size = write_block_file(target, read_buffer, blocks_read * block_size, block_id * block_size, &opt);
+				if (opt.torrent_only == 1) {
+					w_size = blocks_read * block_size;
+				} else {
+					w_size = write_block_file(target, read_buffer, blocks_read * block_size, block_id * block_size, &opt);
+				}
 			} else {
 				w_size = write_all(&dfw, write_buffer, write_offset, &opt);
 				if (w_size != write_offset)

--- a/src/main.c
+++ b/src/main.c
@@ -800,7 +800,7 @@ int main(int argc, char **argv) {
 					    torrent_update(&torrent, write_buffer, blocks_write * block_size);
 
 					    if (opt.torrent_only == 1) {
-						w_size = locks_write * block_size;
+						w_size = blocks_write * block_size;
 					    } else {
 					    	w_size = write_block_file(target, write_buffer + blocks_written * block_size,
 							blocks_write * block_size, (block_id*block_size), &opt);

--- a/src/main.c
+++ b/src/main.c
@@ -235,8 +235,10 @@ int main(int argc, char **argv) {
 		log_mesg(2, 0, 0, debug, "check main bitmap pointer %p\n", bitmap);
 		log_mesg(1, 0, 0, debug, "Writing super block and bitmap...\n");
 
-		write_image_desc(&dfw, fs_info, img_opt, &opt);
-		write_image_bitmap(&dfw, fs_info, img_opt, bitmap, &opt);
+		if (opt.blockfile == 0) {
+			write_image_desc(&dfw, fs_info, img_opt, &opt);
+			write_image_bitmap(&dfw, fs_info, img_opt, bitmap, &opt);
+		}
 
 		log_mesg(0, 0, 1, debug, "done!\n");
 

--- a/src/main.c
+++ b/src/main.c
@@ -799,8 +799,12 @@ int main(int argc, char **argv) {
 
 					    torrent_update(&torrent, write_buffer, blocks_write * block_size);
 
-					    w_size = write_block_file(target, write_buffer + blocks_written * block_size,
-						    blocks_write * block_size, (block_id*block_size), &opt);
+					    if (opt.torrent_only == 1) {
+						w_size = locks_write * block_size;
+					    } else {
+					    	w_size = write_block_file(target, write_buffer + blocks_written * block_size,
+							blocks_write * block_size, (block_id*block_size), &opt);
+					    }
 					}else{
 					    w_size = write_all(&dfw, write_buffer + blocks_written * block_size,
 						    blocks_write * block_size, &opt);
@@ -1039,7 +1043,11 @@ int main(int argc, char **argv) {
                                         
 					torrent_update(&torrent, buffer, rescue_write_size);
 
-                                        w_size = write_block_file(target, buffer, rescue_write_size, copied*block_size, &opt);
+					if (opt.torrent_only == 1) {
+						w_size = rescue_write_size;
+					} else {
+                                        	w_size = write_block_file(target, buffer, rescue_write_size, copied*block_size, &opt);
+					}
                                     } else {
                                         w_size = write_all(&dfw, buffer, rescue_write_size, &opt);
                                     }
@@ -1062,7 +1070,11 @@ int main(int argc, char **argv) {
 
 			    torrent_update(&torrent, buffer, blocks_read * block_size);
 
-			    w_size = write_block_file(target, buffer, blocks_read * block_size, copied*block_size, &opt);
+			    if (opt.torrent_only == 1) {
+				    w_size = blocks_read * block_size;
+			    } else {
+			 	w_size = write_block_file(target, buffer, blocks_read * block_size, copied*block_size, &opt);
+			    }
 			} else {
 			    w_size = write_all(&dfw, buffer, blocks_read * block_size, &opt);
 			}

--- a/src/partclone.c
+++ b/src/partclone.c
@@ -521,7 +521,7 @@ void parse_options(int argc, char **argv, cmd_opt* opt) {
 				break;
 			case 't':
 				opt->blockfile = 1;
-				opt->torrent = 1;
+				opt->torrent_only = 1;
 				break;
 			case 'E':
                 assert(optarg != NULL);

--- a/src/partclone.c
+++ b/src/partclone.c
@@ -253,6 +253,7 @@ void usage(void) {
 		"    -q,  --quiet            Disable progress message\n"
 		"    -E,  --offset=X         Add offset X (bytes) to OUTPUT\n"
 		"    -T,  --btfiles          Restore block as file for ClonezillaBT\n"
+		"    -t,  --btfiles_torrent  Restore block as file for ClonezillaBT but only generate torrent\n"
 #endif
 		"    -n,  --note NOTE        Display Message Note (128 words)\n"
 		"    -v,  --version          Display partclone version\n"
@@ -315,11 +316,11 @@ void parse_options(int argc, char **argv, cmd_opt* opt) {
 #if CHKIMG
 	static const char *sopt = "-hvd::L:s:f:CFiBz:Nn:";
 #elif RESTORE
-	static const char *sopt = "-hvd::L:o:O:s:f:CFINiqWBz:E:n:T";
+	static const char *sopt = "-hvd::L:o:O:s:f:CFINiqWBz:E:n:Tt";
 #elif DD
-	static const char *sopt = "-hvd::L:o:O:s:f:CFINiqWBz:E:n:T";
+	static const char *sopt = "-hvd::L:o:O:s:f:CFINiqWBz:E:n:Tt";
 #else
-	static const char *sopt = "-hvd::L:cx:brDo:O:s:f:RCFINiqWBz:E:a:k:Kn:T";
+	static const char *sopt = "-hvd::L:cx:brDo:O:s:f:RCFINiqWBz:E:a:k:Kn:Tt";
 #endif
 
 	static const struct option lopt[] = {
@@ -363,6 +364,7 @@ void parse_options(int argc, char **argv, cmd_opt* opt) {
 		{ "quiet",		no_argument,		NULL,   'q' },
 		{ "offset",		required_argument,	NULL,   'E' },
 		{ "btfiles",		no_argument,		NULL,   'T' },
+		{ "btfiles_torrent",	no_argument,		NULL,   't' },
 #endif
 #ifdef HAVE_LIBNCURSESW
 		{ "ncurses",		no_argument,		NULL,   'N' },
@@ -516,6 +518,10 @@ void parse_options(int argc, char **argv, cmd_opt* opt) {
 				break;
 			case 'T':
 				opt->blockfile = 1;
+				break;
+			case 't':
+				opt->blockfile = 1;
+				opt->torrent = 1;
 				break;
 			case 'E':
                 assert(optarg != NULL);

--- a/src/partclone.h
+++ b/src/partclone.h
@@ -112,8 +112,7 @@ struct cmd_opt
     int ignore_crc;
     int quiet;
     int blockfile;
-    /* torrent only flag */
-    int torrent;
+    int torrent_only;
     int no_block_detail;
     int restore_raw_file;
     int skip_write_error;

--- a/src/partclone.h
+++ b/src/partclone.h
@@ -112,6 +112,8 @@ struct cmd_opt
     int ignore_crc;
     int quiet;
     int blockfile;
+    /* torrent only flag */
+    int torrent;
     int no_block_detail;
     int restore_raw_file;
     int skip_write_error;

--- a/src/torrent_helper.c
+++ b/src/torrent_helper.c
@@ -1,0 +1,88 @@
+/**
+ * torrent_helper.c - Part of Partclone project.
+ *
+ * Copyright (c) 2019~ Thomas Tsai <thomas at nchc org tw>
+ *
+ * function and structure used by main.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+#include "torrent_helper.h"
+
+void torrent_init(torrent_generator *torrent, int tinfo)
+{
+	torrent->PIECE_SIZE = DEFAULT_PIECE_SIZE;
+	torrent->length = 0;
+	torrent->tinfo = tinfo;
+	SHA1_Init(&torrent->ctx);
+}
+
+void torrent_update(torrent_generator *torrent, void *buffer, size_t length)
+{
+	unsigned long long sha_length = torrent->length;
+	unsigned long long BT_PIECE_SIZE = torrent->PIECE_SIZE;
+	unsigned long long sha_remain_length = BT_PIECE_SIZE - sha_length;
+	unsigned long long buffer_remain_length = length;
+	unsigned long long buffer_offset = 0;
+
+	int tinfo = torrent->tinfo;
+
+	while (buffer_remain_length > 0) {
+		sha_remain_length = BT_PIECE_SIZE - sha_length;
+		if (sha_remain_length <= 0) {
+			// finish a piece
+			SHA1_Final(torrent->hash, &torrent->ctx);
+			dprintf(tinfo, "sha1: ");
+			for (int x = 0; x < SHA_DIGEST_LENGTH; x++) {
+				dprintf(tinfo, "%02x", torrent->hash[x]);
+			}
+			dprintf(tinfo, "\n");
+			// start for next piece;
+			SHA1_Init(&torrent->ctx);
+			sha_length = 0;
+			sha_remain_length = BT_PIECE_SIZE;
+		}
+		if (buffer_remain_length <= 0) {
+			break;
+		}
+		else if (sha_remain_length > buffer_remain_length) {
+			SHA1_Update(&torrent->ctx, buffer + buffer_offset, buffer_remain_length);
+			sha_length += buffer_remain_length;
+			break;
+		}
+		else {
+			SHA1_Update(&torrent->ctx, buffer + buffer_offset, sha_remain_length);
+			buffer_offset += sha_remain_length;
+			buffer_remain_length -= sha_remain_length;
+			sha_length += sha_remain_length;
+		}
+	}
+
+	torrent->length = sha_length;
+}
+
+void torrent_final(torrent_generator *torrent)
+{
+	if (torrent->length) {
+		SHA1_Final(torrent->hash, &torrent->ctx);
+		dprintf(torrent->tinfo, "sha1: ");
+		for (int x = 0; x < SHA_DIGEST_LENGTH; x++) {
+			dprintf(torrent->tinfo, "%02x", torrent->hash[x]);
+		}
+		dprintf(torrent->tinfo, "\n");
+	}
+}
+
+void torrent_start_offset(torrent_generator *torrent, unsigned long long offset)
+{
+	dprintf(torrent->tinfo, "offset: %032llx\n", offset);
+}
+
+void torrent_end_length(torrent_generator *torrent, unsigned long long length)
+{
+	dprintf(torrent->tinfo, "length: %032llx\n", length);
+}

--- a/src/torrent_helper.h
+++ b/src/torrent_helper.h
@@ -1,0 +1,48 @@
+/**
+ * torrent_helper.h - Part of Partclone project.
+ *
+ * Copyright (c) 2019~ Thomas Tsai <thomas at nchc org tw>
+ *
+ * function and structure used by main.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+/*
+ * This helper will help you to generate `torrent.info` for partclone_create_torrent.py
+ * It will output `offset`, `length`, `sha1` for torrent
+ * https://github.com/tjjh89017/ezio utils/partclone_create_torrent.py
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+
+/* SHA1 for torrent info */
+#include <openssl/sha.h>
+
+#define DEFAULT_PIECE_SIZE (16ULL * 1024 * 1024)
+
+typedef struct {
+	unsigned long long PIECE_SIZE;
+	unsigned char hash[SHA_DIGEST_LENGTH];
+	/* fd for torrent.infoi. You should close fd yourself */
+	int tinfo;
+	/* remember the length for a piece size */
+	SHA_CTX ctx;
+	size_t length;
+} torrent_generator;
+
+// init
+void torrent_init(torrent_generator *torrent, int tinfo);
+// put or write data
+void torrent_update(torrent_generator *torrent, void *buffer, size_t length);
+// flush all sha1 hash for end
+void torrent_final(torrent_generator *torrent);
+// print offset, start a block
+void torrent_start_offset(torrent_generator *torrent, unsigned long long offset);
+// print length, end a block
+void torrent_end_length(torrent_generator *torrent, unsigned long long length);

--- a/src/torrent_helper.h
+++ b/src/torrent_helper.h
@@ -29,7 +29,7 @@
 typedef struct {
 	unsigned long long PIECE_SIZE;
 	unsigned char hash[SHA_DIGEST_LENGTH];
-	/* fd for torrent.infoi. You should close fd yourself */
+	/* fd for torrent.info. You should close fd yourself */
 	int tinfo;
 	/* remember the length for a piece size */
 	SHA_CTX ctx;


### PR DESCRIPTION
1. we can `restore` image to BT format and generate `torrent.info` for `partclone_create_torrent.py` [1] simultaneously
2. we can `clone` disk but no output image for BT deploy read/write from disk directly. We don't need to create partclone image and then convert it to BT format. It will generate `torrent.info` directly for use.

Limited:
There is possible that `restore` and `clone` mode generate different `torrent.info`. But two `torrent.info` will cover the same range of disk, so don't worry about that

[1] This script is under developed. it still needs some fix https://github.com/tjjh89017/ezio/blob/master/utils/partclone_create_torrent.py