### PR TITLE
Fixup when torrent_only enable, we don't need to check disk free space

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -221,7 +221,8 @@ int main(int argc, char **argv) {
 		read_bitmap(source, fs_info, bitmap, pui);
 		update_used_blocks_count(&fs_info, bitmap);
 
-		if (opt.check) {
+		/* skip check free space while torrent_only on */
+		if ((opt.check) && (opt.torrent_only == 0)) {
 
 			unsigned long long needed_space = 0;
 
@@ -355,7 +356,8 @@ int main(int argc, char **argv) {
 		read_bitmap(source, fs_info, bitmap, pui);
 
 		/// check the dest partition size.
-		if (opt.check) {
+		/* skip check free space while torrent_only on */
+		if ((opt.check) && (opt.torrent_only == 0)) {
 		    struct stat target_stat;
 		    if ((stat(opt.target, &target_stat) != -1) && (strcmp(opt.target, "-") != 0)) {
 			if (S_ISBLK(target_stat.st_mode)) 

--- a/src/main.c
+++ b/src/main.c
@@ -670,7 +670,7 @@ int main(int argc, char **argv) {
 		if (opt.blockfile == 1) {
 			char torrent_name[PATH_MAX + 1] = {'\0'};
 			sprintf(torrent_name,"%s/torrent.info", target);
-			tinfo = open(torrent_name, O_RDWR | O_CREAT, S_IRUSR | S_IWUSR);
+			tinfo = open(torrent_name, O_RDWR | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR);
 
 			torrent_init(&torrent, tinfo);
 		}
@@ -1001,7 +1001,7 @@ int main(int argc, char **argv) {
 		if (opt.blockfile == 1) {
 			char torrent_name[PATH_MAX + 1] = {'\0'};
 			sprintf(torrent_name,"%s/torrent.info", target);
-			tinfo = open(torrent_name, O_RDWR | O_CREAT, S_IRUSR | S_IWUSR);
+			tinfo = open(torrent_name, O_RDWR | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR);
 			torrent_init(&torrent, tinfo);
 		}
 

--- a/src/main.c
+++ b/src/main.c
@@ -276,7 +276,7 @@ int main(int argc, char **argv) {
 			check_free_space(target, fs_info.device_size);
 		else if ((opt.check) && (opt.blockfile == 0))
 			check_size(&dfw, fs_info.device_size);
-		else if (opt.blockfile == 1)
+		else if (opt.blockfile == 1 && opt.torrent_only == 0)
 			check_free_space(target, fs_info.usedblocks*fs_info.block_size);
 #endif
 

--- a/src/partclone.c
+++ b/src/partclone.c
@@ -1634,7 +1634,7 @@ int open_target(char* target, cmd_opt* opt) {
 			}
 			log_mesg(0, 0, 1, debug, "%s,%s,%i: open %s error(%i)\n", __FILE__, __func__, __LINE__, target, errno);
 		}
-	} else if ((opt->restore || (ddd_block_device == 0)) && (opt->blockfile == 1)) {    /// always is folder
+	} else if ((opt->clone || opt->restore || (ddd_block_device == 0)) && (opt->blockfile == 1)) {    /// always is folder
 
 	    if ((stat(target, &st_dev) == -1) || (opt->overwrite)){
 		remove_directory(target);
@@ -1643,7 +1643,7 @@ int open_target(char* target, cmd_opt* opt) {
 		    log_mesg(0, 0, 1, debug, "%s,%s,%i: open %s error(%i)\n", __FILE__, __func__, __LINE__, target, errno);
 		}
 		ret = 0;
-	    } else {
+	    } else if (opt->torrent_only == 0) {
 		log_mesg(1, 1, 1, debug, "%s,%s,%i: directory %s exist\n", __FILE__, __func__, __LINE__, target);
 	    }
 	}


### PR DESCRIPTION
Because we don't use too much disk space.
Torrent is small enough