### PR TITLE
Fixup buffer address passed into torrent helper in restore mode

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -801,7 +801,7 @@ int main(int argc, char **argv) {
 					    torrent_start_offset(&torrent, block_id * block_size);
 					    torrent_end_length(&torrent, blocks_write * block_size);
 
-					    torrent_update(&torrent, write_buffer, blocks_write * block_size);
+					    torrent_update(&torrent, write_buffer + blocks_written * block_size, blocks_write * block_size);
 
 					    if (opt.torrent_only == 1) {
 						w_size = blocks_write * block_size;


### PR DESCRIPTION
in restore mode (convert partclone image to BT image)
correct the args passed into torrent helper