### PR TITLE
Fix for issue #121

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -746,7 +746,7 @@ int main(int argc, char **argv) {
 
 				read_offset += block_size;
 			}
-			if (blocks_in_cs && blocks_per_cs && blocks_read < buffer_capacity &&
+			if (!opt.ignore_crc && blocks_in_cs && blocks_per_cs && blocks_read < buffer_capacity &&
 					(blocks_read % blocks_per_cs)) {
 
 			    log_mesg(1, 0, 0, debug, "check latest chunk's checksum covering %u blocks\n", blocks_in_cs);


### PR DESCRIPTION
If opt.ignore_crc is set, must not check the (uncomputed) checksum of
the latest chunk

Although I have not studied the code in details, this seems to fix the problem.