### PR TITLE
xfs: avoid redefinitions due to additions in recent xfsprogs

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -133,6 +133,12 @@
 /* Define to 1 if you have the <unistd.h> header file. */
 #undef HAVE_UNISTD_H
 
+/* Define to 1 if your <xfs/xfs_types.h> defines enum xfs_ag_resv_type. */
+#undef HAVE_XFS_AG_RESV_TYPE
+
+/* Define to 1 if your <xfs/xfs_types.h> defines xfs_icount_range(). */
+#undef HAVE_XFS_ICOUNT_RANGE
+
 /* Name of package */
 #undef PACKAGE
 

--- a/configure.ac
+++ b/configure.ac
@@ -103,10 +103,20 @@ AC_ARG_ENABLE([xfs],
 )
 AM_CONDITIONAL(ENABLE_XFS, test "$enable_xfs" = yes)
 
-if test "$enable_xfs" = "yes"; then
-supported_fs=$supported_fs" xfs"
-xfs_version="build-in"
-fi
+AS_IF([test "$enable_xfs" = "yes"], [
+	supported_fs=$supported_fs" xfs"
+	xfs_version="build-in"
+	AC_CHECK_TYPE([enum xfs_ag_resv_type],
+		[AC_DEFINE(HAVE_XFS_AG_RESV_TYPE, 1, [Define to 1 if your <xfs/xfs_types.h> defines enum xfs_ag_resv_type.])],
+		[],
+		[[#include <xfs/xfs.h>]]
+	)
+	AC_CHECK_DECL([xfs_icount_range],
+		[AC_DEFINE(HAVE_XFS_ICOUNT_RANGE, 1, [Define to 1 if your <xfs/xfs_types.h> defines xfs_icount_range().])],
+		[],
+		[[#include <xfs/xfs.h>]]
+	)
+])
 #end of check xfs
 
 ##reiserfs##

--- a/src/xfs/include/xfs.h
+++ b/src/xfs/include/xfs.h
@@ -5,6 +5,8 @@
 #ifndef __XFS_H__
 #define __XFS_H__
 
+#include <config.h>
+
 #if defined(__linux__)
 #include <xfs/linux.h>
 #else

--- a/src/xfs/include/xfs_mount.h
+++ b/src/xfs/include/xfs_mount.h
@@ -104,6 +104,7 @@ typedef struct xfs_mount {
 	struct xlog		*m_log;
 } xfs_mount_t;
 
+#if !HAVE_XFS_AG_RESV_TYPE
 /* per-AG block reservation data structures*/
 enum xfs_ag_resv_type {
 	XFS_AG_RESV_NONE = 0,
@@ -111,6 +112,7 @@ enum xfs_ag_resv_type {
 	XFS_AG_RESV_METADATA,
 	XFS_AG_RESV_RMAPBT,
 };
+#endif
 
 struct xfs_ag_resv {
 	/* number of blocks originally reserved here */

--- a/src/xfs/libxfs/xfs_types.c
+++ b/src/xfs/libxfs/xfs_types.c
@@ -173,7 +173,10 @@ xfs_verify_rtbno(
 }
 
 /* Calculate the range of valid icount values. */
-static void
+#if !HAVE_XFS_ICOUNT_RANGE
+static
+#endif
+void
 xfs_icount_range(
 	struct xfs_mount	*mp,
 	unsigned long long	*min,


### PR DESCRIPTION
Partclone fails to compile due to recent changes in xfsprogs:

* [xfs: add online scrub for superblock counters (`e9caede`)](https://git.kernel.org/pub/scm/fs/xfs/xfsprogs-dev.git/commit/libxfs/xfs_types.h?id=e9caede6e2f5691b18798d88e236314af8c72f20)
* [xfs: add kmem allocation trace points (`7494550`)](https://git.kernel.org/pub/scm/fs/xfs/xfsprogs-dev.git/commit/libxfs/xfs_types.h?id=74945501524d393ab5b3b78179f03a44ab9691c3)

This pull request modifies Partclone's local copy of libxfs so that…
* it only defines `enum xfs_ag_resv_type` if it's not already defined in `<xfs/xfs_types.h>`, and
* it only defines `void xfs_icount_range(struct xfs_mount, unsigned long long, unsigned long long)` as `static` if it's not already defined (non-static) in `<xfs/xfs_types.h>`.