### PR TITLE
fix: crash when backing up swap partition

### DIFF
--- a/src/progress.c
+++ b/src/progress.c
@@ -42,8 +42,12 @@ extern void progress_init(struct progress_bar *prog, int start, unsigned long lo
     prog->start = start;
     prog->stop = stop;
     prog->total = total;
-    prog->unit = 100.0 / (stop - start);
-    prog->total_unit = 100.0 / (total - start);
+
+    if ((stop - stop) != 0) {
+        prog->unit = 100.0 / (stop - start);
+        prog->total_unit = 100.0 / (total - start);
+    }
+
     prog->initial_time = time(0);
     prog->resolution_time = time(0);
     prog->interval_time = 1;
@@ -82,11 +86,11 @@ extern void close_pui(int pui){
 }
 
 extern void update_pui(struct progress_bar *prog, unsigned long long copied, unsigned long long current, int done){
-    
+
     if (done != 1) {
 	if ((difftime(time(0), prog->resolution_time) < prog->interval_time) && copied != 0)
 	    return;
-	
+
     }
     if (prog->pui == NCURSES)
         Ncurses_progress_update(prog, copied, current, done);
@@ -264,7 +268,7 @@ extern void Ncurses_progress_update(struct progress_bar *prog, unsigned long lon
         mvwprintw(bar_win, 0, 0, "%s", blockbuf);
         wattroff(bar_win, COLOR_PAIR(4));
         mvwprintw(p_win, 4, 52, "%6.2f%%", prog_stat.percent);
-        
+
 	if (prog->flag == IO) {
 	    werase(tbar_win);
 	    mvwprintw(p_win, 6, 0, "Total Block Process:");


### PR DESCRIPTION
args: -s /dev/nvme0n1p5 -o - -c -z 1048576 -L /var/log/partclone.log

/dev/nvme0n1p5 is the swap partition, I noticed that in the calculate_speed function of progress.c, percent = prog->unit * copied; percent is NaN, prog->unit is Inf, so the next judgment was not successfully modified percent, which caused the retained to be the wrong value, and the strftime function crashed.