### PR TITLE
Use EVP OpenSSL API

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -22,6 +22,12 @@
    */
 #undef HAVE_DCGETTEXT
 
+/* OpenSSL 1.0+ */
+#undef HAVE_EVP_MD_CTX_create
+
+/* OpenSSL 1.1.0+ */
+#undef HAVE_EVP_MD_CTX_new
+
 /* Define to 1 if you have the <ext2fs/ext2fs.h> header file. */
 #undef HAVE_EXT2FS_EXT2FS_H
 

--- a/configure.ac
+++ b/configure.ac
@@ -415,6 +415,9 @@ AC_CHECK_LIB([ncursesw], [initscr], ,
     AC_MSG_ERROR([*** Ncursesw library (libncursesw5) not found]))
 fi
 
+##libcrypto##
+AC_CHECK_LIB(crypto, EVP_MD_CTX_new, [AC_DEFINE([HAVE_EVP_MD_CTX_new],1,[OpenSSL 1.1.0+])])
+AC_CHECK_LIB(crypto, EVP_MD_CTX_create, [AC_DEFINE([HAVE_EVP_MD_CTX_create],1,[OpenSSL 1.0+])])
 
 ##static linking##
 AC_ARG_ENABLE([static],

--- a/src/torrent_helper.c
+++ b/src/torrent_helper.c
@@ -18,7 +18,15 @@ void torrent_init(torrent_generator *torrent, int tinfo)
 	torrent->PIECE_SIZE = DEFAULT_PIECE_SIZE;
 	torrent->length = 0;
 	torrent->tinfo = tinfo;
+#if defined(HAVE_EVP_MD_CTX_new)
+	torrent->ctx = EVP_MD_CTX_new();
+	EVP_DigestInit(torrent->ctx, EVP_sha1());
+#elif defined(HAVE_EVP_MD_CTX_create)
+	torrent->ctx = EVP_MD_CTX_create();
+	EVP_DigestInit(torrent->ctx, EVP_sha1());
+#else
 	SHA1_Init(&torrent->ctx);
+#endif
 }
 
 void torrent_update(torrent_generator *torrent, void *buffer, size_t length)
@@ -36,14 +44,23 @@ void torrent_update(torrent_generator *torrent, void *buffer, size_t length)
 		sha_remain_length = BT_PIECE_SIZE - sha_length;
 		if (sha_remain_length <= 0) {
 			// finish a piece
+#if defined(HAVE_EVP_MD_CTX_new) || defined(HAVE_EVP_MD_CTX_create)
+			EVP_DigestFinal(torrent->ctx, torrent->hash, NULL);
+#else
 			SHA1_Final(torrent->hash, &torrent->ctx);
+#endif
 			dprintf(tinfo, "sha1: ");
 			for (x = 0; x < SHA_DIGEST_LENGTH; x++) {
 				dprintf(tinfo, "%02x", torrent->hash[x]);
 			}
 			dprintf(tinfo, "\n");
 			// start for next piece;
+#if defined(HAVE_EVP_MD_CTX_new) || defined(HAVE_EVP_MD_CTX_create)
+			EVP_MD_CTX_reset(torrent->ctx);
+			EVP_DigestInit(torrent->ctx, EVP_sha1());
+#else
 			SHA1_Init(&torrent->ctx);
+#endif
 			sha_length = 0;
 			sha_remain_length = BT_PIECE_SIZE;
 		}
@@ -51,12 +68,20 @@ void torrent_update(torrent_generator *torrent, void *buffer, size_t length)
 			break;
 		}
 		else if (sha_remain_length > buffer_remain_length) {
+#if defined(HAVE_EVP_MD_CTX_new) || defined(HAVE_EVP_MD_CTX_create)
+			EVP_DigestUpdate(torrent->ctx, buffer + buffer_offset, buffer_remain_length);
+#else
 			SHA1_Update(&torrent->ctx, buffer + buffer_offset, buffer_remain_length);
+#endif
 			sha_length += buffer_remain_length;
 			break;
 		}
 		else {
+#if defined(HAVE_EVP_MD_CTX_new) || defined(HAVE_EVP_MD_CTX_create)
+			EVP_DigestUpdate(torrent->ctx, buffer + buffer_offset, sha_remain_length);
+#else
 			SHA1_Update(&torrent->ctx, buffer + buffer_offset, sha_remain_length);
+#endif
 			buffer_offset += sha_remain_length;
 			buffer_remain_length -= sha_remain_length;
 			sha_length += sha_remain_length;
@@ -71,7 +96,16 @@ void torrent_final(torrent_generator *torrent)
 	int x = 0;
 
 	if (torrent->length) {
+#if defined(HAVE_EVP_MD_CTX_new) || defined(HAVE_EVP_MD_CTX_create)
+		EVP_DigestFinal(torrent->ctx, torrent->hash, NULL);
+# ifdef HAVE_EVP_MD_CTX_new
+		EVP_MD_CTX_free(ctxt);
+# else
+		EVP_MD_CTX_destroy(ctxt);
+# endif
+#else
 		SHA1_Final(torrent->hash, &torrent->ctx);
+#endif
 		dprintf(torrent->tinfo, "sha1: ");
 		for (x = 0; x < SHA_DIGEST_LENGTH; x++) {
 			dprintf(torrent->tinfo, "%02x", torrent->hash[x]);

--- a/src/torrent_helper.h
+++ b/src/torrent_helper.h
@@ -22,17 +22,25 @@
 #include <stdint.h>
 
 /* SHA1 for torrent info */
+#if defined(HAVE_EVP_MD_CTX_new) || defined(HAVE_EVP_MD_CTX_create)
+#include <openssl/evp.h>
+#else
 #include <openssl/sha.h>
+#endif
 
 #define DEFAULT_PIECE_SIZE (16ULL * 1024 * 1024)
 
 typedef struct {
 	unsigned long long PIECE_SIZE;
-	unsigned char hash[SHA_DIGEST_LENGTH];
+	unsigned char hash[20]; /* SHA_DIGEST_LENGTH, only present in <openssl/sha.h> */
 	/* fd for torrent.info. You should close fd yourself */
 	int tinfo;
 	/* remember the length for a piece size */
+#if defined(HAVE_EVP_MD_CTX_new) || defined(HAVE_EVP_MD_CTX_create)
+	EVP_MD_CTX *ctxt;
+#else
 	SHA_CTX ctx;
+#endif
 	size_t length;
 } torrent_generator;
 


### PR DESCRIPTION
OpenSSL 3.0 deprecated the direct / individual crypto API variants
so they produce deprecation warnings now. OpenSSL also allows hiding
deprecated APIs so in this configuration partclone can't be built.

Signed-off-by: Zoltán Böszörményi <zboszor@gmail.com>