### PR TITLE
Fix using EVP OpenSSL API

### DIFF
--- a/src/torrent_helper.c
+++ b/src/torrent_helper.c
@@ -50,7 +50,7 @@ void torrent_update(torrent_generator *torrent, void *buffer, size_t length)
 			SHA1_Final(torrent->hash, &torrent->ctx);
 #endif
 			dprintf(tinfo, "sha1: ");
-			for (x = 0; x < SHA_DIGEST_LENGTH; x++) {
+			for (x = 0; x < 20 /* SHA_DIGEST_LENGTH */; x++) {
 				dprintf(tinfo, "%02x", torrent->hash[x]);
 			}
 			dprintf(tinfo, "\n");
@@ -96,18 +96,17 @@ void torrent_final(torrent_generator *torrent)
 	int x = 0;
 
 	if (torrent->length) {
-#if defined(HAVE_EVP_MD_CTX_new) || defined(HAVE_EVP_MD_CTX_create)
+#if defined(HAVE_EVP_MD_CTX_new)
 		EVP_DigestFinal(torrent->ctx, torrent->hash, NULL);
-# ifdef HAVE_EVP_MD_CTX_new
-		EVP_MD_CTX_free(ctxt);
-# else
-		EVP_MD_CTX_destroy(ctxt);
-# endif
+		EVP_MD_CTX_free(torrent->ctx);
+#elif defined(HAVE_EVP_MD_CTX_create)
+		EVP_DigestFinal(torrent->ctx, torrent->hash, NULL);
+		EVP_MD_CTX_destroy(torrent->ctx);
 #else
 		SHA1_Final(torrent->hash, &torrent->ctx);
 #endif
 		dprintf(torrent->tinfo, "sha1: ");
-		for (x = 0; x < SHA_DIGEST_LENGTH; x++) {
+		for (x = 0; x < 20 /* SHA_DIGEST_LENGTH */; x++) {
 			dprintf(torrent->tinfo, "%02x", torrent->hash[x]);
 		}
 		dprintf(torrent->tinfo, "\n");

--- a/src/torrent_helper.h
+++ b/src/torrent_helper.h
@@ -17,6 +17,7 @@
  * https://github.com/tjjh89017/ezio utils/partclone_create_torrent.py
  */
 
+#include <config.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
@@ -37,7 +38,7 @@ typedef struct {
 	int tinfo;
 	/* remember the length for a piece size */
 #if defined(HAVE_EVP_MD_CTX_new) || defined(HAVE_EVP_MD_CTX_create)
-	EVP_MD_CTX *ctxt;
+	EVP_MD_CTX *ctx;
 #else
 	SHA_CTX ctx;
 #endif


### PR DESCRIPTION
torrent_helper.h didn't have #include <config.h> so
the settings didn't actually take effect so the direct SHA1 API
was still in use.

Also fix copy&paste errors that didn't turn up in the build
but after adding #include <config.h> to torrent_helper.h they did.

Signed-off-by: Zoltán Böszörményi <zboszor@gmail.com>

This is a follow up to #165
Sorry for the mess, I only actually tested the build before on a system with  OpenSSL 1.1.1l.