### PR TITLE
Docs typo "normanly"

### DIFF
--- a/docs/partclone.8
+++ b/docs/partclone.8
@@ -2,12 +2,12 @@
 .\"     Title: PARTCLONE
 .\"    Author: Yu-Chin Tsai <thomas@nchc.org.tw>
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 02/24/2022
+.\"      Date: 03/01/2022
 .\"    Manual: Partclone User Manual
 .\"    Source: partclone
 .\"  Language: English
 .\"
-.TH "PARTCLONE" "8" "02/24/2022" "partclone" "Partclone User Manual"
+.TH "PARTCLONE" "8" "03/01/2022" "partclone" "Partclone User Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -75,14 +75,14 @@ The program follows the usual GNU command line syntax, with long options startin
 .PP
 \fB\-s \fR\fB\fIFILE\fR\fR, \fB\-\-source \fR\fB\fIFILE\fR\fR
 .RS 4
-Source FILE\&. The FILE could be a image file(made by partclone) or device depend on your action\&. Normanly, backup source is device, restore source is image file\&.
+Source FILE\&. The FILE could be a image file(made by partclone) or device depend on your action\&. Normally, backup source is device, restore source is image file\&.
 .sp
 Receving data from pipe line is supported ONLY for restoring, just ignore \-s option or use \*(Aq\-\*(Aq means receive data from stdin\&.
 .RE
 .PP
 \fB\-o \fR\fB\fIFILE\fR\fR, \fB\-\-output \fR\fB\fIFILE\fR\fR
 .RS 4
-Output FILE\&. The FILE could be a image file(partclone will generate) or device depend on your action\&. Normanly, backup output to image file and restore output to device\&.
+Output FILE\&. The FILE could be a image file(partclone will generate) or device depend on your action\&. Normally, backup output to image file and restore output to device\&.
 .sp
 Sending data to pipe line is also supported ONLY for back\-up, just ignore \-o option or use \*(Aq\-\*(Aq means send data to stdout\&.
 .RE

--- a/docs/partclone.chkimg.8
+++ b/docs/partclone.chkimg.8
@@ -2,12 +2,12 @@
 .\"     Title: PARTCLONE.CHKIMG
 .\"    Author: Yu-Chin Tsai <thomas@nchc.org.tw>
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 06/12/2021
+.\"      Date: 03/01/2022
 .\"    Manual: Partclone User Manual
 .\"    Source: partclone.chkimg
 .\"  Language: English
 .\"
-.TH "PARTCLONE\&.CHKIMG" "8" "06/12/2021" "partclone.chkimg" "Partclone User Manual"
+.TH "PARTCLONE\&.CHKIMG" "8" "03/01/2022" "partclone.chkimg" "Partclone User Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -47,7 +47,7 @@ The program follows the usual GNU command line syntax, with long options startin
 .PP
 \fB\-s \fR\fB\fIFILE\fR\fR, \fB\-\-source \fR\fB\fIFILE\fR\fR
 .RS 4
-Source FILE\&. The FILE could be a image file(made by partclone) or device depend on your action\&. Normanly, backup source is device, restore source is image file\&.
+Source FILE\&. The FILE could be a image file(made by partclone) or device depend on your action\&. Normally, backup source is device, restore source is image file\&.
 .sp
 Receving data from pipe line is supported ONLY for restoring, just ignore \-s option or use \*(Aq\-\*(Aq means receive data from stdin\&.
 .RE

--- a/docs/partclone.chkimg.xml
+++ b/docs/partclone.chkimg.xml
@@ -168,7 +168,7 @@ man(1), man(7), http://www.tldp.org/HOWTO/Man-Page/
         <term><option>-s <replaceable>FILE</replaceable></option></term>
         <term><option>--source <replaceable>FILE</replaceable></option></term>
         <listitem>
-          <para>Source FILE. The FILE could be a image file(made by partclone) or device depend on your action. Normanly, backup source is device, restore source is image file.</para>
+          <para>Source FILE. The FILE could be a image file(made by partclone) or device depend on your action. Normally, backup source is device, restore source is image file.</para>
           <para>Receving data from pipe line is supported ONLY for restoring, just ignore -s option or use '-' means receive data from stdin.</para>
         </listitem>
       </varlistentry>

--- a/docs/partclone.dd.8
+++ b/docs/partclone.dd.8
@@ -2,12 +2,12 @@
 .\"     Title: PARTCLONE.DD
 .\"    Author: Yu-Chin Tsai <thomas@nchc.org.tw>
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 06/12/2021
+.\"      Date: 03/01/2022
 .\"    Manual: Partclone User Manual
 .\"    Source: partclone.dd
 .\"  Language: English
 .\"
-.TH "PARTCLONE\&.DD" "8" "06/12/2021" "partclone.dd" "Partclone User Manual"
+.TH "PARTCLONE\&.DD" "8" "03/01/2022" "partclone.dd" "Partclone User Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -47,14 +47,14 @@ The program follows the usual GNU command line syntax, with long options startin
 .PP
 \fB\-s \fR\fB\fIFILE\fR\fR, \fB\-\-source \fR\fB\fIFILE\fR\fR
 .RS 4
-Source FILE\&. The FILE could be a image file(made by partclone) or device depend on your action\&. Normanly, backup source is device, restore source is image file\&.
+Source FILE\&. The FILE could be a image file(made by partclone) or device depend on your action\&. Normally, backup source is device, restore source is image file\&.
 .sp
 Receving data from pipe line is supported ONLY for restoring, just ignore \-s option or use \*(Aq\-\*(Aq means receive data from stdin\&.
 .RE
 .PP
 \fB\-o \fR\fB\fIFILE\fR\fR, \fB\-\-output \fR\fB\fIFILE\fR\fR
 .RS 4
-Output FILE\&. The FILE could be a image file(partclone will generate) or device depend on your action\&. Normanly, backup output to image file and restore output to device\&.
+Output FILE\&. The FILE could be a image file(partclone will generate) or device depend on your action\&. Normally, backup output to image file and restore output to device\&.
 .sp
 Sending data to pipe line is also supported ONLY for back\-up, just ignore \-o option or use \*(Aq\-\*(Aq means send data to stdout\&.
 .RE

--- a/docs/partclone.dd.xml
+++ b/docs/partclone.dd.xml
@@ -200,7 +200,7 @@ man(1), man(7), http://www.tldp.org/HOWTO/Man-Page/
         <term><option>-s <replaceable>FILE</replaceable></option></term>
         <term><option>--source <replaceable>FILE</replaceable></option></term>
         <listitem>
-          <para>Source FILE. The FILE could be a image file(made by partclone) or device depend on your action. Normanly, backup source is device, restore source is image file.</para>
+          <para>Source FILE. The FILE could be a image file(made by partclone) or device depend on your action. Normally, backup source is device, restore source is image file.</para>
           <para>Receving data from pipe line is supported ONLY for restoring, just ignore -s option or use '-' means receive data from stdin.</para>
         </listitem>
       </varlistentry>
@@ -208,7 +208,7 @@ man(1), man(7), http://www.tldp.org/HOWTO/Man-Page/
         <term><option>-o <replaceable>FILE</replaceable></option></term>
         <term><option>--output <replaceable>FILE</replaceable></option></term>
         <listitem>
-          <para>Output FILE. The FILE could be a image file(partclone will generate) or device depend on your action. Normanly, backup output to image file and restore output to device.</para>
+          <para>Output FILE. The FILE could be a image file(partclone will generate) or device depend on your action. Normally, backup output to image file and restore output to device.</para>
 	  <para>Sending data to pipe line is also supported ONLY for back-up, just ignore -o option or use '-' means send data to stdout.</para>
         </listitem>
       </varlistentry>

--- a/docs/partclone.imager.8
+++ b/docs/partclone.imager.8
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: PARTCLONE.IMAGER
 .\"    Author: Yu-Chin Tsai <thomas@nchc.org.tw>
-.\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
-.\"      Date: 10/28/2021
+.\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
+.\"      Date: 03/01/2022
 .\"    Manual: Partclone User Manual
 .\"    Source: partclone.imager
 .\"  Language: English
 .\"
-.TH "PARTCLONE\&.IMAGER" "8" "10/28/2021" "partclone.imager" "Partclone User Manual"
+.TH "PARTCLONE\&.IMAGER" "8" "03/01/2022" "partclone.imager" "Partclone User Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -47,14 +47,14 @@ The program follows the usual GNU command line syntax, with long options startin
 .PP
 \fB\-s \fR\fB\fIFILE\fR\fR, \fB\-\-source \fR\fB\fIFILE\fR\fR
 .RS 4
-Source FILE\&. The FILE could be a image file(made by partclone) or device depend on your action\&. Normanly, backup source is device, restore source is image file\&.
+Source FILE\&. The FILE could be a image file(made by partclone) or device depend on your action\&. Normally, backup source is device, restore source is image file\&.
 .sp
 Receving data from pipe line is supported ONLY for restoring, just ignore \-s option or use \*(Aq\-\*(Aq means receive data from stdin\&.
 .RE
 .PP
 \fB\-o \fR\fB\fIFILE\fR\fR, \fB\-\-output \fR\fB\fIFILE\fR\fR
 .RS 4
-Output FILE\&. The FILE could be a image file(partclone will generate) or device depend on your action\&. Normanly, backup output to image file and restore output to device\&.
+Output FILE\&. The FILE could be a image file(partclone will generate) or device depend on your action\&. Normally, backup output to image file and restore output to device\&.
 .sp
 Sending data to pipe line is also supported ONLY for back\-up, just ignore \-o option or use \*(Aq\-\*(Aq means send data to stdout\&.
 .RE

--- a/docs/partclone.imager.xml
+++ b/docs/partclone.imager.xml
@@ -233,7 +233,7 @@ man(1), man(7), http://www.tldp.org/HOWTO/Man-Page/
         <term><option>-s <replaceable>FILE</replaceable></option></term>
         <term><option>--source <replaceable>FILE</replaceable></option></term>
         <listitem>
-          <para>Source FILE. The FILE could be a image file(made by partclone) or device depend on your action. Normanly, backup source is device, restore source is image file.</para>
+          <para>Source FILE. The FILE could be a image file(made by partclone) or device depend on your action. Normally, backup source is device, restore source is image file.</para>
           <para>Receving data from pipe line is supported ONLY for restoring, just ignore -s option or use '-' means receive data from stdin.</para>
         </listitem>
       </varlistentry>
@@ -241,7 +241,7 @@ man(1), man(7), http://www.tldp.org/HOWTO/Man-Page/
         <term><option>-o <replaceable>FILE</replaceable></option></term>
         <term><option>--output <replaceable>FILE</replaceable></option></term>
         <listitem>
-          <para>Output FILE. The FILE could be a image file(partclone will generate) or device depend on your action. Normanly, backup output to image file and restore output to device.</para>
+          <para>Output FILE. The FILE could be a image file(partclone will generate) or device depend on your action. Normally, backup output to image file and restore output to device.</para>
 	  <para>Sending data to pipe line is also supported ONLY for back-up, just ignore -o option or use '-' means send data to stdout.</para>
         </listitem>
       </varlistentry>

--- a/docs/partclone.restore.8
+++ b/docs/partclone.restore.8
@@ -2,12 +2,12 @@
 .\"     Title: PARTCLONE.RESTORE
 .\"    Author: Yu-Chin Tsai <thomas@nchc.org.tw>
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 06/12/2021
+.\"      Date: 03/01/2022
 .\"    Manual: Partclone User Manual
 .\"    Source: partclone.restore
 .\"  Language: English
 .\"
-.TH "PARTCLONE\&.RESTORE" "8" "06/12/2021" "partclone.restore" "Partclone User Manual"
+.TH "PARTCLONE\&.RESTORE" "8" "03/01/2022" "partclone.restore" "Partclone User Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -47,14 +47,14 @@ The program follows the usual GNU command line syntax, with long options startin
 .PP
 \fB\-s \fR\fB\fIFILE\fR\fR, \fB\-\-source \fR\fB\fIFILE\fR\fR
 .RS 4
-Source FILE\&. The FILE could be a image file(made by partclone) or device depend on your action\&. Normanly, backup source is device, restore source is image file\&.
+Source FILE\&. The FILE could be a image file(made by partclone) or device depend on your action\&. Normally, backup source is device, restore source is image file\&.
 .sp
 Receving data from pipe line is supported ONLY for restoring, just ignore \-s option or use \*(Aq\-\*(Aq means receive data from stdin\&.
 .RE
 .PP
 \fB\-o \fR\fB\fIFILE\fR\fR, \fB\-\-output \fR\fB\fIFILE\fR\fR
 .RS 4
-Output FILE\&. The FILE could be a image file(partclone will generate) or device depend on your action\&. Normanly, backup output to image file and restore output to device\&.
+Output FILE\&. The FILE could be a image file(partclone will generate) or device depend on your action\&. Normally, backup output to image file and restore output to device\&.
 .sp
 Sending data to pipe line is also supported ONLY for back\-up, just ignore \-o option or use \*(Aq\-\*(Aq means send data to stdout\&.
 .RE

--- a/docs/partclone.restore.xml
+++ b/docs/partclone.restore.xml
@@ -200,7 +200,7 @@ man(1), man(7), http://www.tldp.org/HOWTO/Man-Page/
         <term><option>-s <replaceable>FILE</replaceable></option></term>
         <term><option>--source <replaceable>FILE</replaceable></option></term>
         <listitem>
-          <para>Source FILE. The FILE could be a image file(made by partclone) or device depend on your action. Normanly, backup source is device, restore source is image file.</para>
+          <para>Source FILE. The FILE could be a image file(made by partclone) or device depend on your action. Normally, backup source is device, restore source is image file.</para>
           <para>Receving data from pipe line is supported ONLY for restoring, just ignore -s option or use '-' means receive data from stdin.</para>
         </listitem>
       </varlistentry>
@@ -208,7 +208,7 @@ man(1), man(7), http://www.tldp.org/HOWTO/Man-Page/
         <term><option>-o <replaceable>FILE</replaceable></option></term>
         <term><option>--output <replaceable>FILE</replaceable></option></term>
         <listitem>
-          <para>Output FILE. The FILE could be a image file(partclone will generate) or device depend on your action. Normanly, backup output to image file and restore output to device.</para>
+          <para>Output FILE. The FILE could be a image file(partclone will generate) or device depend on your action. Normally, backup output to image file and restore output to device.</para>
 	  <para>Sending data to pipe line is also supported ONLY for back-up, just ignore -o option or use '-' means send data to stdout.</para>
         </listitem>
       </varlistentry>

--- a/docs/partclone.xml
+++ b/docs/partclone.xml
@@ -249,7 +249,7 @@ man(1), man(7), http://www.tldp.org/HOWTO/Man-Page/
         <term><option>-s <replaceable>FILE</replaceable></option></term>
         <term><option>--source <replaceable>FILE</replaceable></option></term>
         <listitem>
-          <para>Source FILE. The FILE could be a image file(made by partclone) or device depend on your action. Normanly, backup source is device, restore source is image file.</para>
+          <para>Source FILE. The FILE could be a image file(made by partclone) or device depend on your action. Normally, backup source is device, restore source is image file.</para>
           <para>Receving data from pipe line is supported ONLY for restoring, just ignore -s option or use '-' means receive data from stdin.</para>
         </listitem>
       </varlistentry>
@@ -257,7 +257,7 @@ man(1), man(7), http://www.tldp.org/HOWTO/Man-Page/
         <term><option>-o <replaceable>FILE</replaceable></option></term>
         <term><option>--output <replaceable>FILE</replaceable></option></term>
         <listitem>
-          <para>Output FILE. The FILE could be a image file(partclone will generate) or device depend on your action. Normanly, backup output to image file and restore output to device.</para>
+          <para>Output FILE. The FILE could be a image file(partclone will generate) or device depend on your action. Normally, backup output to image file and restore output to device.</para>
 	  <para>Sending data to pipe line is also supported ONLY for back-up, just ignore -o option or use '-' means send data to stdout.</para>
         </listitem>
       </varlistentry>


### PR DESCRIPTION
Fix issue #170: "normanly" = "in the Norman way" highly unlikely to be intended here, replacing with "normally"