### PR TITLE
Avoid redefining _GNU_SOURCE, _LARGEFILE64_SOURCE

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -12,8 +12,12 @@
  */
 
 #include <config.h>
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
+#ifndef _LARGEFILE64_SOURCE
 #define _LARGEFILE64_SOURCE
+#endif
 #include <errno.h>
 #include <features.h>
 #include <fcntl.h>

--- a/src/partclone.c
+++ b/src/partclone.c
@@ -13,8 +13,12 @@
 
 
 #include <config.h>
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
+#ifndef _LARGEFILE64_SOURCE
 #define _LARGEFILE64_SOURCE
+#endif
 #include <features.h>
 #include <fcntl.h>
 #include <unistd.h>


### PR DESCRIPTION
Prevent compiler warnings and make it more fail-safe.