### PR TITLE
Support FUSE 2.x API

### DIFF
--- a/src/fuseimg.c
+++ b/src/fuseimg.c
@@ -181,7 +181,12 @@ void info_options ()
     opt.info = 1;
     opt.source = image_file;
 }
-static void *main_init(struct fuse_conn_info *conn, struct fuse_config *cfg)
+
+static void *main_init(struct fuse_conn_info *conn
+#if FUSE_MAJOR_VERSION >= 3
+    , struct fuse_config *cfg
+#endif
+)
 {
 
     (void) conn;


### PR DESCRIPTION
Prior to version 3.0, `fuse_init()` did not have a second argument, nor was `struct fuse_config` defined.