### PR TITLE
Check argument count in partclone.imgfuse

### DIFF
--- a/src/fuseimg.c
+++ b/src/fuseimg.c
@@ -294,6 +294,9 @@ static struct fuse_operations ptl_fuse_operations =
 
 int main(int argc, char *argv[])
 {
+    if (argc < 2) {
+        info_usage(); // Never returns.
+    }
     image_file = realpath(argv[argc-2], NULL);
     argv[argc-2] = argv[argc-1];
     argv[argc-1] = NULL;


### PR DESCRIPTION
Print a help page on incorrect `partclone.imgfuse` invocation rather than just crash.