### PR TITLE
Check for EVP_MD_CTX_reset

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -418,6 +418,7 @@ fi
 ##libcrypto##
 AC_CHECK_LIB(crypto, EVP_MD_CTX_new, [AC_DEFINE([HAVE_EVP_MD_CTX_new],1,[OpenSSL 1.1.0+])])
 AC_CHECK_LIB(crypto, EVP_MD_CTX_create, [AC_DEFINE([HAVE_EVP_MD_CTX_create],1,[OpenSSL 1.0+])])
+AC_CHECK_LIB(crypto, EVP_MD_CTX_reset, [AC_DEFINE([HAVE_EVP_MD_CTX_reset],1,[OpenSSL 1.1.0+])])
 
 ##static linking##
 AC_ARG_ENABLE([static],

--- a/src/torrent_helper.h
+++ b/src/torrent_helper.h
@@ -23,7 +23,10 @@
 #include <stdint.h>
 
 /* SHA1 for torrent info */
-#if defined(HAVE_EVP_MD_CTX_new) || defined(HAVE_EVP_MD_CTX_create)
+#if (defined(HAVE_EVP_MD_CTX_new) || defined(HAVE_EVP_MD_CTX_create)) && defined(HAVE_EVP_MD_CTX_reset)
+#define HAVE_EVP_MD_CTX_methods
+#endif
+#if defined(HAVE_EVP_MD_CTX_methods)
 #include <openssl/evp.h>
 #else
 #include <openssl/sha.h>
@@ -37,7 +40,7 @@ typedef struct {
 	/* fd for torrent.info. You should close fd yourself */
 	int tinfo;
 	/* remember the length for a piece size */
-#if defined(HAVE_EVP_MD_CTX_new) || defined(HAVE_EVP_MD_CTX_create)
+#if defined(HAVE_EVP_MD_CTX_methods)
 	EVP_MD_CTX *ctx;
 #else
 	SHA_CTX ctx;


### PR DESCRIPTION
OpenSSL prior to 1.1.0 and LibreSSL prior to 2.7.0 come without `EVP_MD_CTX_reset()`.