### PR TITLE
Avoid uninitialized variables to prevent compiler warnings

### DIFF
--- a/src/btrfs/ctree.c
+++ b/src/btrfs/ctree.c
@@ -3030,7 +3030,7 @@ int btrfs_del_items(struct btrfs_trans_handle *trans, struct btrfs_root *root,
  */
 int btrfs_prev_leaf(struct btrfs_root *root, struct btrfs_path *path)
 {
-	int slot;
+	int slot = 0;
 	int level = 1;
 	struct extent_buffer *c;
 	struct extent_buffer *next = NULL;

--- a/src/btrfs/extent-tree.c
+++ b/src/btrfs/extent-tree.c
@@ -1285,8 +1285,8 @@ int btrfs_lookup_extent_info(struct btrfs_trans_handle *trans,
 	struct extent_buffer *l;
 	struct btrfs_extent_item *item;
 	u32 item_size;
-	u64 num_refs;
-	u64 extent_flags;
+	u64 num_refs = 0;
+	u64 extent_flags = 0;
 
 	if (metadata && !btrfs_fs_incompat(fs_info, SKINNY_METADATA)) {
 		offset = fs_info->nodesize;
@@ -3096,7 +3096,7 @@ out:
 
 static u64 get_dev_extent_len(struct map_lookup *map)
 {
-	int div;
+	int div = 1;
 
 	switch (map->type & BTRFS_BLOCK_GROUP_PROFILE_MASK) {
 	case 0: /* Single */

--- a/src/btrfs/volumes.c
+++ b/src/btrfs/volumes.c
@@ -2491,7 +2491,7 @@ u64 btrfs_stripe_length(struct btrfs_fs_info *fs_info,
 			struct extent_buffer *leaf,
 			struct btrfs_chunk *chunk)
 {
-	u64 stripe_len;
+	u64 stripe_len = 0;
 	u64 chunk_len;
 	u32 num_stripes = btrfs_chunk_num_stripes(leaf, chunk);
 	u64 profile = btrfs_chunk_type(leaf, chunk) &

--- a/src/xfs/libxfs/xfs_sb.c
+++ b/src/xfs/libxfs/xfs_sb.c
@@ -851,7 +851,7 @@ xfs_initialize_perag_data(
 	uint64_t	bfreelst = 0;
 	uint64_t	btree = 0;
 	uint64_t	fdblocks;
-	int		error;
+	int		error = 0;
 
 	for (index = 0; index < agcount; index++) {
 		/*


### PR DESCRIPTION
Make extra-cautious compilers happy.