### PR TITLE
Support unit-testing in out-of-tree builds

### DIFF
--- a/tests/_common
+++ b/tests/_common
@@ -92,11 +92,12 @@ _findmkfs(){
     esac
 
     locate_path=$(type -P locate)
-    if [ -z $locate_path ]; then
-        locate_path="which"
+    if [ -n $locate_path ]; then
+        mkfs_path=$($locate_path mkfs.$fs|grep sbin| sort -n -r |head -n 1)
     fi
-
-    mkfs_path=$($locate_path mkfs.$fs|grep sbin| sort -n -r |head -n 1)
+    if [ -z $mkfs_path ]; then
+        mkfs_path=$(which mkfs.$fs)
+    fi
     if [ -z $mkfs_path ]; then
 	echo  >&2 "can't find mkfs.$fs"
 	exit 1

--- a/tests/btrfs.test
+++ b/tests/btrfs.test
@@ -1,2 +1,2 @@
 #!/bin/bash
-./mini_clone_restore_test -f 115000000 btrfs
+"$(dirname "$0")"/mini_clone_restore_test -f 115000000 btrfs

--- a/tests/checksum.test
+++ b/tests/checksum.test
@@ -1,5 +1,5 @@
 #!/bin/bash
-. _common
+. "$(dirname "$0")"/_common
 
 fs="ext3"
 raw_r="restore.raw"

--- a/tests/data_clone_restore_test
+++ b/tests/data_clone_restore_test
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-. _common
+. "$(dirname "$0")"/_common
 break_debug=0
 manual_fs=$1
 

--- a/tests/dd.test
+++ b/tests/dd.test
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-. _common
+. "$(dirname "$0")"/_common
 fs="dd"
 ptlfs="../src/partclone.dd"
 dd_count=$((normal_size/2))

--- a/tests/domain.test
+++ b/tests/domain.test
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-. _common
+. "$(dirname "$0")"/_common
 ## file system
 fs="ext3"
 dd_count=$normal_size

--- a/tests/exfat.test
+++ b/tests/exfat.test
@@ -1,2 +1,2 @@
 #!/bin/bash
-./mini_clone_restore_test exfat
+"$(dirname "$0")"/mini_clone_restore_test exfat

--- a/tests/ext2.test
+++ b/tests/ext2.test
@@ -1,2 +1,2 @@
 #!/bin/bash
-./mini_clone_restore_test ext2
+"$(dirname "$0")"/mini_clone_restore_test ext2

--- a/tests/ext3.test
+++ b/tests/ext3.test
@@ -1,2 +1,2 @@
 #!/bin/bash
-./mini_clone_restore_test ext3
+"$(dirname "$0")"/mini_clone_restore_test ext3

--- a/tests/ext4.test
+++ b/tests/ext4.test
@@ -1,2 +1,2 @@
 #!/bin/bash
-./mini_clone_restore_test ext4
+"$(dirname "$0")"/mini_clone_restore_test ext4

--- a/tests/f2fs.test
+++ b/tests/f2fs.test
@@ -1,2 +1,2 @@
 #!/bin/bash
-./mini_clone_restore_test f2fs
+"$(dirname "$0")"/mini_clone_restore_test f2fs

--- a/tests/failmbr
+++ b/tests/failmbr
@@ -1,5 +1,5 @@
 #!/bin/bash
 fail_mbr_dir="../fail-mbr"
 hd $fail_mbr_dir/fail-mbr.bin > fail-mbr.hex
-hd $fail_mbr_dir/fail-mbr.bin.orig > fail-mbr.hex.orig
+hd "$(dirname "$0")"/$fail_mbr_dir/fail-mbr.bin.orig > fail-mbr.hex.orig
 diff fail-mbr.hex.orig fail-mbr.hex || true

--- a/tests/fat.test
+++ b/tests/fat.test
@@ -1,4 +1,5 @@
 #!/bin/bash
-./mini_clone_restore_test fat12
-./mini_clone_restore_test fat16
-./mini_clone_restore_test fat32
+srcdir="$(dirname "$0")"
+"${srcdir}"/mini_clone_restore_test fat12
+"${srcdir}"/mini_clone_restore_test fat16
+"${srcdir}"/mini_clone_restore_test fat32

--- a/tests/hfsplus.test
+++ b/tests/hfsplus.test
@@ -1,2 +1,2 @@
 #!/bin/bash
-./mini_clone_restore_test hfsplus
+"$(dirname "$0")"/mini_clone_restore_test hfsplus

--- a/tests/imager.test
+++ b/tests/imager.test
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-. _common
+. "$(dirname "$0")"/_common
 fs="imager"
 ptlfs="../src/partclone.imager"
 dd_count=$((normal_size/2))

--- a/tests/imgfuse.test
+++ b/tests/imgfuse.test
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-. _common
+. "$(dirname "$0")"/_common
 fs="ext4"
 ptlfs="../src/partclone.extfs"
 mkfs=$(_findmkfs $fs)

--- a/tests/info.test
+++ b/tests/info.test
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-. _common
+. "$(dirname "$0")"/_common
 break_debug=0
 ## file system
 normal_fs="ext2"

--- a/tests/jfs.test
+++ b/tests/jfs.test
@@ -1,2 +1,2 @@
 #!/bin/bash
-./mini_clone_restore_test jfs
+"$(dirname "$0")"/mini_clone_restore_test jfs

--- a/tests/mini_clone_restore_test
+++ b/tests/mini_clone_restore_test
@@ -6,7 +6,7 @@ usage(){
     exit 0
 }
 
-. _common
+. "$(dirname "$0")"/_common
 
 ## blocks/checksum to test various patterns
 cs_a=(0   1   1   1   1     1)

--- a/tests/minix.test
+++ b/tests/minix.test
@@ -1,2 +1,2 @@
 #!/bin/bash
-./mini_clone_restore_test minix
+"$(dirname "$0")"/mini_clone_restore_test minix

--- a/tests/ncursesw.test
+++ b/tests/ncursesw.test
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-. _common
+. "$(dirname "$0")"/_common
 fs="ext3"
 ptlfs="../src/partclone.extfs"
 mkfs=$(_findmkfs $fs)

--- a/tests/nilfs2.test
+++ b/tests/nilfs2.test
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-. _common
+. "$(dirname "$0")"/_common
 manual_fs="nilfs2"
 _check_root
 

--- a/tests/note.test
+++ b/tests/note.test
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-. _common
+. "$(dirname "$0")"/_common
 fs="dd"
 ptlfs="../src/partclone.dd"
 dd_count=$((normal_size/2))

--- a/tests/ntfs.test
+++ b/tests/ntfs.test
@@ -1,2 +1,2 @@
 #!/bin/bash
-./mini_clone_restore_test ntfs
+"$(dirname "$0")"/mini_clone_restore_test ntfs

--- a/tests/offset.test
+++ b/tests/offset.test
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-. _common
+. "$(dirname "$0")"/_common
 
 disk_size=$((512*1024576))
 row_A_file=$0.row_A

--- a/tests/pipe.test
+++ b/tests/pipe.test
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-. _common
+. "$(dirname "$0")"/_common
 fs="ext3"
 ptlfs="../src/partclone.extfs"
 dd_count=$((normal_size/2))

--- a/tests/quiet.test
+++ b/tests/quiet.test
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-. _common
+. "$(dirname "$0")"/_common
 ## file system
 fs="ext3"
 dd_count=$normal_size

--- a/tests/reiser4.test
+++ b/tests/reiser4.test
@@ -1,2 +1,2 @@
 #!/bin/bash
-./mini_clone_restore_test reiser4
+"$(dirname "$0")"/mini_clone_restore_test reiser4

--- a/tests/reiserfs.test
+++ b/tests/reiserfs.test
@@ -1,2 +1,2 @@
 #!/bin/bash
-./mini_clone_restore_test reiserfs
+"$(dirname "$0")"/mini_clone_restore_test reiserfs

--- a/tests/restore_to_raw.test
+++ b/tests/restore_to_raw.test
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-. _common
+. "$(dirname "$0")"/_common
 ## file system
 fs="ext3"
 dd_count=$normal_size

--- a/tests/xfs.test
+++ b/tests/xfs.test
@@ -1,2 +1,2 @@
 #!/bin/bash
-./mini_clone_restore_test xfs
+"$(dirname "$0")"/mini_clone_restore_test xfs


### PR DESCRIPTION
Actually tested in full scale (via `make check`):
* dd.test
* ext2.test
* ext3.test
* ext4.test
* btrfs.test
* fat.test
* xfs.test
* exfat.test
* ntfs.test
* ncursesw.test

Not fully tested due to `mkfs.*` absence on the host:
* hfsplus.test
* f2fs.test

Deliberately excluded *prestable.test* due to it appearing very private, with hard-coded absolute paths.

Special note about `locate` vs `which`: the former appears to be more troublesome as it may not be properly configured in some systems out-of-the-box, and therefore requires to fall back to the latter even if both utilities are present.