### PR TITLE
fix log message to add new line after "Open devicefile successfully"

### DIFF
--- a/src/xfsclone.c
+++ b/src/xfsclone.c
@@ -262,7 +262,7 @@ static void fs_open(char* device)
     if ((source_fd = open(device, open_flags)) < 0)  {
 	log_mesg(0, 1, 1, fs_opt.debug, "%s: Couldn't open source partition %s\n", __FILE__, device);
     }else{
-	log_mesg(0, 0, 0, fs_opt.debug, "%s: Open %s successfully", __FILE__, device);
+	log_mesg(0, 0, 0, fs_opt.debug, "%s: Open %s successfully\n", __FILE__, device);
 	}
 
     if (fstat(source_fd, &statbuf) < 0)  {


### PR DESCRIPTION
log message output as follows, so add new line.

```
Initial image hdr - get Super Block from partition
Reading Super Block
xfsclone.c: Open /dev/sda9 successfullyxfsclone.c: source_blocksize 4096 source_sectorsize = 512
xfsclone.c: first_residue 2048 tmp_residue 2048
```

Thank you.