### PR TITLE
Add missing space before opening parenthesis

### DIFF
--- a/docs/partclone.8
+++ b/docs/partclone.8
@@ -39,7 +39,7 @@ partclone \- The utility for clone and restore a partition\&.
 project\&. Partclone provide utilities to backup used blocks and design for higher compatibility of the file system by using existing library, e\&.g\&. e2fslibs is used to read the used block of ext2 partition\&.
 .PP
 \fBPartclone\fR
-supported file system include btrfs, ext2, ext3, ext4, reiserfs, reiser4, xfs and jfs for LINUX\&. Also support some non\-linux operation system, ex: NTFS, FAT and EXFAT(for Windows), HFS plus(APPLE MAC OS), UFS2(FreeBSD), VMFS(VMWare Vsphere) and MINIX(MINIX3)\&.
+supported file system include btrfs, ext2, ext3, ext4, reiserfs, reiser4, xfs and jfs for LINUX\&. Also support some non\-linux operation system, ex: NTFS, FAT and EXFAT (for Windows), HFS plus (APPLE MAC OS), UFS2 (FreeBSD), VMFS (VMWare Vsphere) and MINIX (MINIX3)\&.
 .PP
 All partclone utils could be run like partclone\&.[fstype] is very smiliar fsck or mkfs\&. For example, for backup/restore hfsplus, just run partclone\&.hfsp
 .sp
@@ -75,14 +75,14 @@ The program follows the usual GNU command line syntax, with long options startin
 .PP
 \fB\-s \fR\fB\fIFILE\fR\fR, \fB\-\-source \fR\fB\fIFILE\fR\fR
 .RS 4
-Source FILE\&. The FILE could be a image file(made by partclone) or device depend on your action\&. Normally, backup source is device, restore source is image file\&.
+Source FILE\&. The FILE could be a image file (made by partclone) or device depend on your action\&. Normally, backup source is device, restore source is image file\&.
 .sp
 Receving data from pipe line is supported ONLY for restoring, just ignore \-s option or use \*(Aq\-\*(Aq means receive data from stdin\&.
 .RE
 .PP
 \fB\-o \fR\fB\fIFILE\fR\fR, \fB\-\-output \fR\fB\fIFILE\fR\fR
 .RS 4
-Output FILE\&. The FILE could be a image file(partclone will generate) or device depend on your action\&. Normally, backup output to image file and restore output to device\&.
+Output FILE\&. The FILE could be a image file (partclone will generate) or device depend on your action\&. Normally, backup output to image file and restore output to device\&.
 .sp
 Sending data to pipe line is also supported ONLY for back\-up, just ignore \-o option or use \*(Aq\-\*(Aq means send data to stdout\&.
 .RE
@@ -124,7 +124,7 @@ Creating special raw file for loop device\&.
 .PP
 \fB\-L \fR\fB\fIFILE\fR\fR, \fB\-\-logfile \fR\fB\fIFILE\fR\fR
 .RS 4
-put special path to record partclone log information\&.(default /var/log/partclone\&.log)
+put special path to record partclone log information\&. (default /var/log/partclone\&.log)
 .RE
 .PP
 \fB\-R\fR, \fB\-\-rescue\fR
@@ -210,7 +210,7 @@ partclone
  restore /dev/hda1 from hda1\&.img and display debug information\&.
    partclone\&.extfs \-r \-d \-s hda1\&.img \-o /dev/hda1
 
- restore image from clonezilla(split, gzip,) with stdin source
+ restore image from clonezilla (split, gzip,) with stdin source
    cat sda1\&.ext3\-ptcl\-img\&.gz\&.a* | gunzip \-c | partclone\&.ext3 \-d \-r \-s \- \-o /dev/sda1
     
 .fi

--- a/docs/partclone.chkimg.8
+++ b/docs/partclone.chkimg.8
@@ -40,21 +40,21 @@ is a part of
 project to verify image files\&. Partclone provide utilities to backup used blocks and design for higher compatibility of the file system by using existing library, e\&.g\&. e2fslibs is used to read the used block of ext2 partition\&.
 .PP
 \fBPartclone\fR
-supported file system include btrfs, ext2, ext3, ext4, reiserfs, reiser4, xfs and jfs for LINUX\&. Also support some non\-linux operation system, ex: NTFS, FAT, EXFAT(for Windows), HFS plus(APPLE MAC OS), UFS2(FreeBSD), VMFS(VMWare Vsphere)\&. All partclone utils could be run like partclone\&.xxx is very smiliar fsck or mkfs\&. For example, for backup/restore hfsplus, just run partclone\&.hfsp\&.
+supported file system include btrfs, ext2, ext3, ext4, reiserfs, reiser4, xfs and jfs for LINUX\&. Also support some non\-linux operation system, ex: NTFS, FAT, EXFAT (for Windows), HFS plus (APPLE MAC OS), UFS2 (FreeBSD), VMFS (VMWare Vsphere)\&. All partclone utils could be run like partclone\&.xxx is very smiliar fsck or mkfs\&. For example, for backup/restore hfsplus, just run partclone\&.hfsp\&.
 .SH "OPTIONS"
 .PP
 The program follows the usual GNU command line syntax, with long options starting with two dashes (`\-\*(Aq)\&. A summary of options is included below\&.
 .PP
 \fB\-s \fR\fB\fIFILE\fR\fR, \fB\-\-source \fR\fB\fIFILE\fR\fR
 .RS 4
-Source FILE\&. The FILE could be a image file(made by partclone) or device depend on your action\&. Normally, backup source is device, restore source is image file\&.
+Source FILE\&. The FILE could be a image file (made by partclone) or device depend on your action\&. Normally, backup source is device, restore source is image file\&.
 .sp
 Receving data from pipe line is supported ONLY for restoring, just ignore \-s option or use \*(Aq\-\*(Aq means receive data from stdin\&.
 .RE
 .PP
 \fB\-L \fR\fB\fIFILE\fR\fR, \fB\-\-logfile \fR\fB\fIFILE\fR\fR
 .RS 4
-put special path to record partclone log information\&.(default /var/log/partclone\&.log)
+put special path to record partclone log information\&. (default /var/log/partclone\&.log)
 .RE
 .PP
 \fB\-C\fR, \fB\-\-no_check\fR

--- a/docs/partclone.chkimg.xml
+++ b/docs/partclone.chkimg.xml
@@ -152,7 +152,7 @@ man(1), man(7), http://www.tldp.org/HOWTO/Man-Page/
     <title>DESCRIPTION</title>
     <para><command>&dhpackage;</command> is a part of <command>Partclone</command> project to verify image files. 
     Partclone provide utilities to backup used blocks and design for higher compatibility of the file system by using existing library, e.g. e2fslibs is used to read the used block of ext2 partition.</para>
-    <para><command>Partclone</command> supported file system include btrfs, ext2, ext3, ext4, reiserfs, reiser4, xfs and jfs for LINUX. Also  support some non-linux operation system, ex: NTFS, FAT, EXFAT(for Windows), HFS plus(APPLE MAC OS), UFS2(FreeBSD), VMFS(VMWare Vsphere). All partclone utils could be run like partclone.xxx is very smiliar fsck or mkfs. For example, for backup/restore hfsplus, just run partclone.hfsp.
+    <para><command>Partclone</command> supported file system include btrfs, ext2, ext3, ext4, reiserfs, reiser4, xfs and jfs for LINUX. Also  support some non-linux operation system, ex: NTFS, FAT, EXFAT (for Windows), HFS plus (APPLE MAC OS), UFS2 (FreeBSD), VMFS (VMWare Vsphere). All partclone utils could be run like partclone.xxx is very smiliar fsck or mkfs. For example, for backup/restore hfsplus, just run partclone.hfsp.
     </para>
   </refsect1>
   <refsect1 id="options">
@@ -168,7 +168,7 @@ man(1), man(7), http://www.tldp.org/HOWTO/Man-Page/
         <term><option>-s <replaceable>FILE</replaceable></option></term>
         <term><option>--source <replaceable>FILE</replaceable></option></term>
         <listitem>
-          <para>Source FILE. The FILE could be a image file(made by partclone) or device depend on your action. Normally, backup source is device, restore source is image file.</para>
+          <para>Source FILE. The FILE could be a image file (made by partclone) or device depend on your action. Normally, backup source is device, restore source is image file.</para>
           <para>Receving data from pipe line is supported ONLY for restoring, just ignore -s option or use '-' means receive data from stdin.</para>
         </listitem>
       </varlistentry>
@@ -176,7 +176,7 @@ man(1), man(7), http://www.tldp.org/HOWTO/Man-Page/
         <term><option>-L <replaceable>FILE</replaceable></option></term>
         <term><option>--logfile <replaceable>FILE</replaceable></option></term>
         <listitem>
-          <para>put special path to record partclone log information.(default /var/log/partclone.log)</para>
+          <para>put special path to record partclone log information. (default /var/log/partclone.log)</para>
         </listitem>
       </varlistentry>
      <varlistentry>

--- a/docs/partclone.dd.8
+++ b/docs/partclone.dd.8
@@ -28,7 +28,7 @@
 .\" * MAIN CONTENT STARTS HERE *
 .\" -----------------------------------------------------------------
 .SH "NAME"
-partclone.dd \- unsupported file system backup utility\&.(like `dd` )
+partclone.dd \- unsupported file system backup utility\&. (like `dd` )
 .SH "SYNOPSIS"
 .HP \w'\fBpartclone\&.dd\fR\ 'u
 \fBpartclone\&.dd\fR {[\fB\-s\fR\ |\ \fB\-\-source\fR]\ \fIsource\fR} {[[\fB\-o\fR\ |\ \fB\-\-output\fR]\ [\fB\-O\fR\ |\ \fB\-\-overwrite\fR]]\ \fItarget\fR} [[\fB\-dX\fR\ |\ \fB\-\-debug=X\fR]\ [\fB\-\-restore_raw_file\fR]\ [\fB\-z\fR\ |\ \fB\-\-buffer_size\fR]\ [\fB\-N\fR\ |\ \fB\-\-ncurses\fR]\ [\fB\-q\fR\ |\ \fB\-\-quiet\fR]\ [\fB\-f\fR\ |\ \fB\-\-UI\-fresh\fR]\ [\fB\-F\fR\ |\ \fB\-\-force\fR]\ [\fB\-I\fR\ |\ \fB\-\-ignore_fschk\fR]\ [\fB\-\-ignore_crc\fR]\ [\fB\-X\fR\ |\ \fB\-\-dialog\fR]\ [\fB\-C\fR\ |\ \fB\-\-nocheck\fR]\ [\fB\-R\fR\ |\ \fB\-\-rescue\fR]\ [\fB\-L\fR\ |\ \fB\-\-logfile\fR]\ \fIlogfile\fR]
@@ -40,21 +40,21 @@ is a part of
 project to clone unsupported file system with dd method\&. It will backup all block from partition\&. Partclone provide utilities to backup used blocks and design for higher compatibility of the file system by using existing library, e\&.g\&. e2fslibs is used to read the used block of ext2 partition\&.
 .PP
 \fBPartclone\fR
-supported file system include btrfs, ext2, ext3, ext4, reiserfs, reiser4, xfs and jfs for LINUX\&. Also support some non\-linux operation system, ex: NTFS and FAT (for Windows), HFS plus(APPLE MAC OS), UFS2(FreeBSD), VMFS(VMWare Vsphere)\&. All partclone utils could be run like partclone\&.xxx is very smiliar fsck or mkfs\&. For example, for backup/restore hfsplus, just run partclone\&.hfsp\&.
+supported file system include btrfs, ext2, ext3, ext4, reiserfs, reiser4, xfs and jfs for LINUX\&. Also support some non\-linux operation system, ex: NTFS and FAT (for Windows), HFS plus (APPLE MAC OS), UFS2 (FreeBSD), VMFS (VMWare Vsphere)\&. All partclone utils could be run like partclone\&.xxx is very smiliar fsck or mkfs\&. For example, for backup/restore hfsplus, just run partclone\&.hfsp\&.
 .SH "OPTIONS"
 .PP
 The program follows the usual GNU command line syntax, with long options starting with two dashes (`\-\*(Aq)\&. A summary of options is included below\&.
 .PP
 \fB\-s \fR\fB\fIFILE\fR\fR, \fB\-\-source \fR\fB\fIFILE\fR\fR
 .RS 4
-Source FILE\&. The FILE could be a image file(made by partclone) or device depend on your action\&. Normally, backup source is device, restore source is image file\&.
+Source FILE\&. The FILE could be a image file (made by partclone) or device depend on your action\&. Normally, backup source is device, restore source is image file\&.
 .sp
 Receving data from pipe line is supported ONLY for restoring, just ignore \-s option or use \*(Aq\-\*(Aq means receive data from stdin\&.
 .RE
 .PP
 \fB\-o \fR\fB\fIFILE\fR\fR, \fB\-\-output \fR\fB\fIFILE\fR\fR
 .RS 4
-Output FILE\&. The FILE could be a image file(partclone will generate) or device depend on your action\&. Normally, backup output to image file and restore output to device\&.
+Output FILE\&. The FILE could be a image file (partclone will generate) or device depend on your action\&. Normally, backup output to image file and restore output to device\&.
 .sp
 Sending data to pipe line is also supported ONLY for back\-up, just ignore \-o option or use \*(Aq\-\*(Aq means send data to stdout\&.
 .RE
@@ -71,7 +71,7 @@ Creating special raw file for loop device\&.
 .PP
 \fB\-L \fR\fB\fIFILE\fR\fR, \fB\-\-logfile \fR\fB\fIFILE\fR\fR
 .RS 4
-put special path to record partclone log information\&.(default /var/log/partclone\&.log)
+put special path to record partclone log information\&. (default /var/log/partclone\&.log)
 .RE
 .PP
 \fB\-R\fR, \fB\-\-rescue\fR

--- a/docs/partclone.fstype.8
+++ b/docs/partclone.fstype.8
@@ -40,7 +40,7 @@ is a part of
 project to retrieve partition head information from image files\&. Partclone provide utilities to backup used blocks and design for higher compatibility of the file system by using existing library, e\&.g\&. e2fslibs is used to read the used block of ext2 partition\&.
 .PP
 \fBPartclone\fR
-supported file system include btrfs, ext2, ext3, ext4, reiserfs, reiser4, xfs and jfs for LINUX\&. Also support some non\-linux operation system, ex: NTFS, FAT, EXFAT(for Windows), HFS plus(APPLE MAC OS), UFS2(FreeBSD), VMFS(VMWare Vsphere)\&. All partclone utils could be run like partclone\&.xxx is very smiliar fsck or mkfs\&. For example, for backup/restore hfsplus, just run partclone\&.hfsp\&.
+supported file system include btrfs, ext2, ext3, ext4, reiserfs, reiser4, xfs and jfs for LINUX\&. Also support some non\-linux operation system, ex: NTFS, FAT, EXFAT (for Windows), HFS plus (APPLE MAC OS), UFS2 (FreeBSD), VMFS (VMWare Vsphere)\&. All partclone utils could be run like partclone\&.xxx is very smiliar fsck or mkfs\&. For example, for backup/restore hfsplus, just run partclone\&.hfsp\&.
 .SH "OPTIONS"
 .PP
 The program follows the usual GNU command line syntax, with long options starting with two dashes (`\-\*(Aq)\&. A summary of options is included below\&.

--- a/docs/partclone.fstype.xml
+++ b/docs/partclone.fstype.xml
@@ -113,7 +113,7 @@ man(1), man(7), http://www.tldp.org/HOWTO/Man-Page/
     <para><command>&dhpackage;</command> is a part of <command>Partclone</command> project to retrieve partition head information from image files. 
     
     Partclone provide utilities to backup used blocks and design for higher compatibility of the file system by using existing library, e.g. e2fslibs is used to read the used block of ext2 partition.</para>
-    <para><command>Partclone</command> supported file system include btrfs, ext2, ext3, ext4, reiserfs, reiser4, xfs and jfs for LINUX. Also  support some non-linux operation system, ex: NTFS, FAT, EXFAT(for Windows), HFS plus(APPLE MAC OS), UFS2(FreeBSD), VMFS(VMWare Vsphere). All partclone utils could be run like partclone.xxx is very smiliar fsck or mkfs. For example, for backup/restore hfsplus, just run partclone.hfsp.
+    <para><command>Partclone</command> supported file system include btrfs, ext2, ext3, ext4, reiserfs, reiser4, xfs and jfs for LINUX. Also  support some non-linux operation system, ex: NTFS, FAT, EXFAT (for Windows), HFS plus (APPLE MAC OS), UFS2 (FreeBSD), VMFS (VMWare Vsphere). All partclone utils could be run like partclone.xxx is very smiliar fsck or mkfs. For example, for backup/restore hfsplus, just run partclone.hfsp.
 
     </para>
 

--- a/docs/partclone.imager.8
+++ b/docs/partclone.imager.8
@@ -28,7 +28,7 @@
 .\" * MAIN CONTENT STARTS HERE *
 .\" -----------------------------------------------------------------
 .SH "NAME"
-partclone.imager \- unsupported file system backup utility\&.(like `dd` )
+partclone.imager \- unsupported file system backup utility\&. (like `dd` )
 .SH "SYNOPSIS"
 .HP \w'\fBpartclone\&.imager\fR\ 'u
 \fBpartclone\&.imager\fR {[\fB\-c\fR\ |\ \fB\-\-clone\fR]\ [\fB\-r\fR\ |\ \fB\-\-restore\fR]\ [\fB\-b\fR\ |\ \fB\-\-dev\-to\-dev\fR]} {{\fB\-s\fR\ |\ \fB\-\-source\fR}\ \fIsource\fR} {{\fB\-o\fR\ |\ \fB\-\-output\fR}\ [\fB\-O\fR\ |\ \fB\-\-overwrite\fR]\ \fItarget\fR} [\fB\-dX\fR\ |\ \fB\-\-debug=X\fR] [\fB\-\-restore_raw_file\fR] [\fB\-z\fR\ |\ \fB\-\-buffer_size\fR] [\fB\-N\fR\ |\ \fB\-\-ncurses\fR] [\fB\-q\fR\ |\ \fB\-\-quiet\fR] [\fB\-f\fR\ |\ \fB\-\-UI\-fresh\fR] [\fB\-F\fR\ |\ \fB\-\-force\fR] [\fB\-I\fR\ |\ \fB\-\-ignore_fschk\fR] [\fB\-\-ignore_crc\fR]\ [\fB\-X\fR\ |\ \fB\-\-dialog\fR] [\fB\-C\fR\ |\ \fB\-\-nocheck\fR] [\fB\-R\fR\ |\ \fB\-\-rescue\fR] [{\fB\-L\fR\ |\ \fB\-\-logfile\fR}\ \fIlogfile\fR]
@@ -40,21 +40,21 @@ is a part of
 project to clone unsupported file system with dd method\&. It will backup all block from partition\&. Partclone provide utilities to backup used blocks and design for higher compatibility of the file system by using existing library, e\&.g\&. e2fslibs is used to read the used block of ext2 partition\&.
 .PP
 \fBPartclone\fR
-supported file system include btrfs, ext2, ext3, ext4, reiserfs, reiser4, xfs and jfs for LINUX\&. Also support some non\-linux operation system, ex: NTFS and FAT (for Windows), HFS plus(APPLE MAC OS), UFS2(FreeBSD), VMFS(VMWare Vsphere)\&. All partclone utils could be run like partclone\&.xxx is very smiliar fsck or mkfs\&. For example, for backup/restore hfsplus, just run partclone\&.hfsp\&.
+supported file system include btrfs, ext2, ext3, ext4, reiserfs, reiser4, xfs and jfs for LINUX\&. Also support some non\-linux operation system, ex: NTFS and FAT (for Windows), HFS plus (APPLE MAC OS), UFS2 (FreeBSD), VMFS (VMWare Vsphere)\&. All partclone utils could be run like partclone\&.xxx is very smiliar fsck or mkfs\&. For example, for backup/restore hfsplus, just run partclone\&.hfsp\&.
 .SH "OPTIONS"
 .PP
 The program follows the usual GNU command line syntax, with long options starting with two dashes (`\-\*(Aq)\&. A summary of options is included below\&.
 .PP
 \fB\-s \fR\fB\fIFILE\fR\fR, \fB\-\-source \fR\fB\fIFILE\fR\fR
 .RS 4
-Source FILE\&. The FILE could be a image file(made by partclone) or device depend on your action\&. Normally, backup source is device, restore source is image file\&.
+Source FILE\&. The FILE could be a image file (made by partclone) or device depend on your action\&. Normally, backup source is device, restore source is image file\&.
 .sp
 Receving data from pipe line is supported ONLY for restoring, just ignore \-s option or use \*(Aq\-\*(Aq means receive data from stdin\&.
 .RE
 .PP
 \fB\-o \fR\fB\fIFILE\fR\fR, \fB\-\-output \fR\fB\fIFILE\fR\fR
 .RS 4
-Output FILE\&. The FILE could be a image file(partclone will generate) or device depend on your action\&. Normally, backup output to image file and restore output to device\&.
+Output FILE\&. The FILE could be a image file (partclone will generate) or device depend on your action\&. Normally, backup output to image file and restore output to device\&.
 .sp
 Sending data to pipe line is also supported ONLY for back\-up, just ignore \-o option or use \*(Aq\-\*(Aq means send data to stdout\&.
 .RE
@@ -86,7 +86,7 @@ Creating special raw file for loop device\&.
 .PP
 \fB\-L \fR\fB\fIFILE\fR\fR, \fB\-\-logfile \fR\fB\fIFILE\fR\fR
 .RS 4
-put special path to record partclone log information\&.(default /var/log/partclone\&.log)
+put special path to record partclone log information\&. (default /var/log/partclone\&.log)
 .RE
 .PP
 \fB\-R\fR, \fB\-\-rescue\fR

--- a/docs/partclone.imager.xml
+++ b/docs/partclone.imager.xml
@@ -97,7 +97,7 @@ man(1), man(7), http://www.tldp.org/HOWTO/Man-Page/
   </refmeta>
   <refnamediv>
     <refname>&dhpackage;</refname>
-    <refpurpose>unsupported file system backup utility.(like `dd` )</refpurpose>
+    <refpurpose>unsupported file system backup utility. (like `dd` )</refpurpose>
   </refnamediv>
   <refsynopsisdiv>
     <cmdsynopsis>
@@ -217,7 +217,7 @@ man(1), man(7), http://www.tldp.org/HOWTO/Man-Page/
     <title>DESCRIPTION</title>
     <para><command>&dhpackage;</command> is a part of <command>Partclone</command> project to clone unsupported file system with dd method. It will backup all block from partition.
     Partclone provide utilities to backup used blocks and design for higher compatibility of the file system by using existing library, e.g. e2fslibs is used to read the used block of ext2 partition.</para>
-    <para><command>Partclone</command> supported file system include btrfs, ext2, ext3, ext4, reiserfs, reiser4, xfs and jfs for LINUX. Also  support some non-linux operation system, ex: NTFS and  FAT (for Windows), HFS plus(APPLE MAC OS), UFS2(FreeBSD), VMFS(VMWare Vsphere). All partclone utils could be run like partclone.xxx is very smiliar fsck or mkfs. For example, for backup/restore hfsplus, just run partclone.hfsp.
+    <para><command>Partclone</command> supported file system include btrfs, ext2, ext3, ext4, reiserfs, reiser4, xfs and jfs for LINUX. Also  support some non-linux operation system, ex: NTFS and  FAT (for Windows), HFS plus (APPLE MAC OS), UFS2 (FreeBSD), VMFS (VMWare Vsphere). All partclone utils could be run like partclone.xxx is very smiliar fsck or mkfs. For example, for backup/restore hfsplus, just run partclone.hfsp.
     </para>
   </refsect1>
   <refsect1 id="options">
@@ -233,7 +233,7 @@ man(1), man(7), http://www.tldp.org/HOWTO/Man-Page/
         <term><option>-s <replaceable>FILE</replaceable></option></term>
         <term><option>--source <replaceable>FILE</replaceable></option></term>
         <listitem>
-          <para>Source FILE. The FILE could be a image file(made by partclone) or device depend on your action. Normally, backup source is device, restore source is image file.</para>
+          <para>Source FILE. The FILE could be a image file (made by partclone) or device depend on your action. Normally, backup source is device, restore source is image file.</para>
           <para>Receving data from pipe line is supported ONLY for restoring, just ignore -s option or use '-' means receive data from stdin.</para>
         </listitem>
       </varlistentry>
@@ -241,7 +241,7 @@ man(1), man(7), http://www.tldp.org/HOWTO/Man-Page/
         <term><option>-o <replaceable>FILE</replaceable></option></term>
         <term><option>--output <replaceable>FILE</replaceable></option></term>
         <listitem>
-          <para>Output FILE. The FILE could be a image file(partclone will generate) or device depend on your action. Normally, backup output to image file and restore output to device.</para>
+          <para>Output FILE. The FILE could be a image file (partclone will generate) or device depend on your action. Normally, backup output to image file and restore output to device.</para>
 	  <para>Sending data to pipe line is also supported ONLY for back-up, just ignore -o option or use '-' means send data to stdout.</para>
         </listitem>
       </varlistentry>
@@ -283,7 +283,7 @@ man(1), man(7), http://www.tldp.org/HOWTO/Man-Page/
         <term><option>-L <replaceable>FILE</replaceable></option></term>
         <term><option>--logfile <replaceable>FILE</replaceable></option></term>
         <listitem>
-          <para>put special path to record partclone log information.(default /var/log/partclone.log)</para>
+          <para>put special path to record partclone log information. (default /var/log/partclone.log)</para>
         </listitem>
       </varlistentry>
       <varlistentry>

--- a/docs/partclone.info.8
+++ b/docs/partclone.info.8
@@ -40,14 +40,14 @@ is a part of
 project to retrieve partition head information from image files\&. Partclone provide utilities to backup used blocks and design for higher compatibility of the file system by using existing library, e\&.g\&. e2fslibs is used to read the used block of ext2 partition\&.
 .PP
 \fBPartclone\fR
-supported file system include btrfs, ext2, ext3, ext4, reiserfs, reiser4, xfs and jfs for LINUX\&. Also support some non\-linux operation system, ex: NTFS, FAT, EXFAT(for Windows), HFS plus(APPLE MAC OS), UFS2(FreeBSD), VMFS(VMWare Vsphere)\&. All partclone utils could be run like partclone\&.xxx is very smiliar fsck or mkfs\&. For example, for backup/restore hfsplus, just run partclone\&.hfsp\&.
+supported file system include btrfs, ext2, ext3, ext4, reiserfs, reiser4, xfs and jfs for LINUX\&. Also support some non\-linux operation system, ex: NTFS, FAT, EXFAT (for Windows), HFS plus (APPLE MAC OS), UFS2 (FreeBSD), VMFS (VMWare Vsphere)\&. All partclone utils could be run like partclone\&.xxx is very smiliar fsck or mkfs\&. For example, for backup/restore hfsplus, just run partclone\&.hfsp\&.
 .SH "OPTIONS"
 .PP
 The program follows the usual GNU command line syntax, with long options starting with two dashes (`\-\*(Aq)\&. A summary of options is included below\&.
 .PP
 \fB\fIFILE\fR\fR
 .RS 4
-Image FILE\&. The FILE could be a image file(made by partclone)\&.
+Image FILE\&. The FILE could be a image file (made by partclone)\&.
 .RE
 .SH "EXAMPLES"
 .sp

--- a/docs/partclone.info.xml
+++ b/docs/partclone.info.xml
@@ -113,7 +113,7 @@ man(1), man(7), http://www.tldp.org/HOWTO/Man-Page/
     <para><command>&dhpackage;</command> is a part of <command>Partclone</command> project to retrieve partition head information from image files. 
     
     Partclone provide utilities to backup used blocks and design for higher compatibility of the file system by using existing library, e.g. e2fslibs is used to read the used block of ext2 partition.</para>
-    <para><command>Partclone</command> supported file system include btrfs, ext2, ext3, ext4, reiserfs, reiser4, xfs and jfs for LINUX. Also  support some non-linux operation system, ex: NTFS, FAT, EXFAT(for Windows), HFS plus(APPLE MAC OS), UFS2(FreeBSD), VMFS(VMWare Vsphere). All partclone utils could be run like partclone.xxx is very smiliar fsck or mkfs. For example, for backup/restore hfsplus, just run partclone.hfsp.
+    <para><command>Partclone</command> supported file system include btrfs, ext2, ext3, ext4, reiserfs, reiser4, xfs and jfs for LINUX. Also  support some non-linux operation system, ex: NTFS, FAT, EXFAT (for Windows), HFS plus (APPLE MAC OS), UFS2 (FreeBSD), VMFS (VMWare Vsphere). All partclone utils could be run like partclone.xxx is very smiliar fsck or mkfs. For example, for backup/restore hfsplus, just run partclone.hfsp.
 
     </para>
 
@@ -130,7 +130,7 @@ man(1), man(7), http://www.tldp.org/HOWTO/Man-Page/
       <varlistentry>
         <term><option><replaceable>FILE</replaceable></option></term>
         <listitem>
-          <para>Image FILE. The FILE could be a image file(made by partclone).</para>
+          <para>Image FILE. The FILE could be a image file (made by partclone).</para>
         </listitem>
       </varlistentry>
     </variablelist>

--- a/docs/partclone.restore.8
+++ b/docs/partclone.restore.8
@@ -40,21 +40,21 @@ is a part of
 project to restore all image made from partclone\&.[fstype] or partclone\&.dd\&. Partclone provide utilities to backup used blocks and design for higher compatibility of the file system by using existing library, e\&.g\&. e2fslibs is used to read the used block of ext2 partition\&.
 .PP
 \fBPartclone\fR
-supported file system include btrfs, ext2, ext3, ext4, reiserfs, reiser4, xfs and jfs for LINUX\&. Also support some non\-linux operation system, ex: NTFS, FAT, EXFAT(for Windows), HFS plus(APPLE MAC OS), UFS2(FreeBSD), VMFS(VMWare Vsphere)\&. All partclone utils could be run like partclone\&.xxx is very smiliar fsck or mkfs\&. For example, for backup/restore hfsplus, just run partclone\&.hfsp\&.
+supported file system include btrfs, ext2, ext3, ext4, reiserfs, reiser4, xfs and jfs for LINUX\&. Also support some non\-linux operation system, ex: NTFS, FAT, EXFAT (for Windows), HFS plus (APPLE MAC OS), UFS2 (FreeBSD), VMFS (VMWare Vsphere)\&. All partclone utils could be run like partclone\&.xxx is very smiliar fsck or mkfs\&. For example, for backup/restore hfsplus, just run partclone\&.hfsp\&.
 .SH "OPTIONS"
 .PP
 The program follows the usual GNU command line syntax, with long options starting with two dashes (`\-\*(Aq)\&. A summary of options is included below\&.
 .PP
 \fB\-s \fR\fB\fIFILE\fR\fR, \fB\-\-source \fR\fB\fIFILE\fR\fR
 .RS 4
-Source FILE\&. The FILE could be a image file(made by partclone) or device depend on your action\&. Normally, backup source is device, restore source is image file\&.
+Source FILE\&. The FILE could be a image file (made by partclone) or device depend on your action\&. Normally, backup source is device, restore source is image file\&.
 .sp
 Receving data from pipe line is supported ONLY for restoring, just ignore \-s option or use \*(Aq\-\*(Aq means receive data from stdin\&.
 .RE
 .PP
 \fB\-o \fR\fB\fIFILE\fR\fR, \fB\-\-output \fR\fB\fIFILE\fR\fR
 .RS 4
-Output FILE\&. The FILE could be a image file(partclone will generate) or device depend on your action\&. Normally, backup output to image file and restore output to device\&.
+Output FILE\&. The FILE could be a image file (partclone will generate) or device depend on your action\&. Normally, backup output to image file and restore output to device\&.
 .sp
 Sending data to pipe line is also supported ONLY for back\-up, just ignore \-o option or use \*(Aq\-\*(Aq means send data to stdout\&.
 .RE
@@ -71,7 +71,7 @@ Creating special raw file for loop device\&.
 .PP
 \fB\-L \fR\fB\fIFILE\fR\fR, \fB\-\-logfile \fR\fB\fIFILE\fR\fR
 .RS 4
-put special path to record partclone log information\&.(default /var/log/partclone\&.log)
+put special path to record partclone log information\&. (default /var/log/partclone\&.log)
 .RE
 .PP
 \fB\-R\fR, \fB\-\-rescue\fR
@@ -154,7 +154,7 @@ partclone\&.restore
  restore /dev/hda1 from hda1\&.img and display debug information\&.
   partclone\&.restore \-d \-s hda1\&.img \-o /dev/hda1
 
- restore image from clonezilla(split, gzip,) with stdin source 
+ restore image from clonezilla (split, gzip,) with stdin source 
   cat  sda1\&.ext3\-ptcl\-img\&.gz\&.a*  | gunzip \-c | partclone\&.restore \-d \-s \- \-o /dev/sda1
 
  restore  raw  image  from  partclone\&.dd  

--- a/docs/partclone.restore.xml
+++ b/docs/partclone.restore.xml
@@ -184,7 +184,7 @@ man(1), man(7), http://www.tldp.org/HOWTO/Man-Page/
     <title>DESCRIPTION</title>
     <para><command>&dhpackage;</command> is a part of <command>Partclone</command> project to restore all image made from partclone.[fstype] or partclone.dd.
     Partclone provide utilities to backup used blocks and design for higher compatibility of the file system by using existing library, e.g. e2fslibs is used to read the used block of ext2 partition.</para>
-    <para><command>Partclone</command> supported file system include btrfs, ext2, ext3, ext4, reiserfs, reiser4, xfs and jfs for LINUX. Also  support some non-linux operation system, ex: NTFS, FAT, EXFAT(for Windows), HFS plus(APPLE MAC OS), UFS2(FreeBSD), VMFS(VMWare Vsphere). All partclone utils could be run like partclone.xxx is very smiliar fsck or mkfs. For example, for backup/restore hfsplus, just run partclone.hfsp.
+    <para><command>Partclone</command> supported file system include btrfs, ext2, ext3, ext4, reiserfs, reiser4, xfs and jfs for LINUX. Also  support some non-linux operation system, ex: NTFS, FAT, EXFAT (for Windows), HFS plus (APPLE MAC OS), UFS2 (FreeBSD), VMFS (VMWare Vsphere). All partclone utils could be run like partclone.xxx is very smiliar fsck or mkfs. For example, for backup/restore hfsplus, just run partclone.hfsp.
     </para>
      </refsect1>
   <refsect1 id="options">
@@ -200,7 +200,7 @@ man(1), man(7), http://www.tldp.org/HOWTO/Man-Page/
         <term><option>-s <replaceable>FILE</replaceable></option></term>
         <term><option>--source <replaceable>FILE</replaceable></option></term>
         <listitem>
-          <para>Source FILE. The FILE could be a image file(made by partclone) or device depend on your action. Normally, backup source is device, restore source is image file.</para>
+          <para>Source FILE. The FILE could be a image file (made by partclone) or device depend on your action. Normally, backup source is device, restore source is image file.</para>
           <para>Receving data from pipe line is supported ONLY for restoring, just ignore -s option or use '-' means receive data from stdin.</para>
         </listitem>
       </varlistentry>
@@ -208,7 +208,7 @@ man(1), man(7), http://www.tldp.org/HOWTO/Man-Page/
         <term><option>-o <replaceable>FILE</replaceable></option></term>
         <term><option>--output <replaceable>FILE</replaceable></option></term>
         <listitem>
-          <para>Output FILE. The FILE could be a image file(partclone will generate) or device depend on your action. Normally, backup output to image file and restore output to device.</para>
+          <para>Output FILE. The FILE could be a image file (partclone will generate) or device depend on your action. Normally, backup output to image file and restore output to device.</para>
 	  <para>Sending data to pipe line is also supported ONLY for back-up, just ignore -o option or use '-' means send data to stdout.</para>
         </listitem>
       </varlistentry>
@@ -229,7 +229,7 @@ man(1), man(7), http://www.tldp.org/HOWTO/Man-Page/
         <term><option>-L <replaceable>FILE</replaceable></option></term>
         <term><option>--logfile <replaceable>FILE</replaceable></option></term>
         <listitem>
-          <para>put special path to record partclone log information.(default /var/log/partclone.log)</para>
+          <para>put special path to record partclone log information. (default /var/log/partclone.log)</para>
         </listitem>
       </varlistentry>
       <varlistentry>
@@ -341,7 +341,7 @@ man(1), man(7), http://www.tldp.org/HOWTO/Man-Page/
  restore /dev/hda1 from hda1.img and display debug information.
   partclone.restore -d -s hda1.img -o /dev/hda1
 
- restore image from clonezilla(split, gzip,) with stdin source 
+ restore image from clonezilla (split, gzip,) with stdin source 
   cat  sda1.ext3-ptcl-img.gz.a*  | gunzip -c | partclone.restore -d -s - -o /dev/sda1
 
  restore  raw  image  from  partclone.dd  

--- a/docs/partclone.xml
+++ b/docs/partclone.xml
@@ -212,7 +212,7 @@ man(1), man(7), http://www.tldp.org/HOWTO/Man-Page/
   <refsect1 id="description">
     <title>DESCRIPTION</title>
     <para><command>&dhpackage;</command>.[fstype] is a part of <command>Partclone</command> project. Partclone provide utilities to backup used blocks and design for higher compatibility of the file system by using existing library, e.g. e2fslibs is used to read the used block of ext2 partition.</para>
-    <para><command>Partclone</command> supported file system include btrfs, ext2, ext3, ext4, reiserfs, reiser4, xfs and jfs for LINUX. Also  support some non-linux operation system, ex: NTFS, FAT and EXFAT(for Windows), HFS plus(APPLE MAC OS), UFS2(FreeBSD), VMFS(VMWare Vsphere) and MINIX(MINIX3).
+    <para><command>Partclone</command> supported file system include btrfs, ext2, ext3, ext4, reiserfs, reiser4, xfs and jfs for LINUX. Also  support some non-linux operation system, ex: NTFS, FAT and EXFAT (for Windows), HFS plus (APPLE MAC OS), UFS2 (FreeBSD), VMFS (VMWare Vsphere) and MINIX (MINIX3).
     </para>
     <para>All partclone utils could be run like partclone.[fstype] is very smiliar fsck or mkfs. For example, for backup/restore hfsplus, just run partclone.hfsp
     </para>
@@ -249,7 +249,7 @@ man(1), man(7), http://www.tldp.org/HOWTO/Man-Page/
         <term><option>-s <replaceable>FILE</replaceable></option></term>
         <term><option>--source <replaceable>FILE</replaceable></option></term>
         <listitem>
-          <para>Source FILE. The FILE could be a image file(made by partclone) or device depend on your action. Normally, backup source is device, restore source is image file.</para>
+          <para>Source FILE. The FILE could be a image file (made by partclone) or device depend on your action. Normally, backup source is device, restore source is image file.</para>
           <para>Receving data from pipe line is supported ONLY for restoring, just ignore -s option or use '-' means receive data from stdin.</para>
         </listitem>
       </varlistentry>
@@ -257,7 +257,7 @@ man(1), man(7), http://www.tldp.org/HOWTO/Man-Page/
         <term><option>-o <replaceable>FILE</replaceable></option></term>
         <term><option>--output <replaceable>FILE</replaceable></option></term>
         <listitem>
-          <para>Output FILE. The FILE could be a image file(partclone will generate) or device depend on your action. Normally, backup output to image file and restore output to device.</para>
+          <para>Output FILE. The FILE could be a image file (partclone will generate) or device depend on your action. Normally, backup output to image file and restore output to device.</para>
 	  <para>Sending data to pipe line is also supported ONLY for back-up, just ignore -o option or use '-' means send data to stdout.</para>
         </listitem>
       </varlistentry>
@@ -312,7 +312,7 @@ man(1), man(7), http://www.tldp.org/HOWTO/Man-Page/
         <term><option>-L <replaceable>FILE</replaceable></option></term>
         <term><option>--logfile <replaceable>FILE</replaceable></option></term>
         <listitem>
-          <para>put special path to record partclone log information.(default /var/log/partclone.log)</para>
+          <para>put special path to record partclone log information. (default /var/log/partclone.log)</para>
         </listitem>
       </varlistentry>
       <varlistentry>
@@ -427,7 +427,7 @@ man(1), man(7), http://www.tldp.org/HOWTO/Man-Page/
  restore /dev/hda1 from hda1.img and display debug information.
    partclone.extfs -r -d -s hda1.img -o /dev/hda1
 
- restore image from clonezilla(split, gzip,) with stdin source
+ restore image from clonezilla (split, gzip,) with stdin source
    cat sda1.ext3-ptcl-img.gz.a* | gunzip -c | partclone.ext3 -d -r -s - -o /dev/sda1
     </screen>
     </refsect1>


### PR DESCRIPTION
When writing in English (not a programming language or math), the rule is: put a space before the opening parenthesis.