### PR TITLE
Skip FAT tests on big-endian architectures

### DIFF
--- a/tests/fat.test
+++ b/tests/fat.test
@@ -1,4 +1,8 @@
 #!/bin/bash
+# src/fatclone.c supports only little-endian (always fails on s390x)
+le="$(echo -n I | hexdump -o | awk '{ print substr($2, 6, 1); exit}')"
+[[ "${le}" != "0" ]] || exit 77
+
 srcdir="$(dirname "$0")"
 "${srcdir}"/mini_clone_restore_test fat12
 "${srcdir}"/mini_clone_restore_test fat16


### PR DESCRIPTION
Otherwise `src/fatclone.c` fails on s390x like this:
> get_fat_type, 66, ERROR: data_size count error
> get_fat_type, 70, ERROR: clusters count error

Alternatively, if you need access to an s390x system to add big-endian support to `src/fatclone.c`, please let me know.