### PR TITLE
Skip F2FS tests on big-endian architectures

### DIFF
--- a/tests/f2fs.test
+++ b/tests/f2fs.test
@@ -1,2 +1,6 @@
 #!/bin/bash
+# partclone.f2fs supports only little-endian (always fails on s390x)
+le="$(echo -n I | hexdump -o | awk '{ print substr($2, 6, 1); exit}')"
+[[ "${le}" != "0" ]] || exit 77
+
 "$(dirname "$0")"/mini_clone_restore_test f2fs


### PR DESCRIPTION
Otherwise `partclone.f2fs` fails on s390x like this:
> $ partclone.f2fs -d -c -s floppy.raw -O floppy.img -F -L test.log -a 1 -k 17
> Segmentation fault      (core dumped)

Alternatively, if you need access to an s390x system to add big-endian support to `partclone.f2fs`, please let me know.