### PR TITLE
Handle absence of mtrace.h (e.g. uClibc) gracefully

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -79,6 +79,9 @@
 /* Define to 1 if you have the <mqueue.h> header file. */
 #undef HAVE_MQUEUE_H
 
+/* Define to 1 if you have the <mtrace.h> header file. */
+#undef HAVE_MTRACE_H
+
 /* Define to 1 if you have the <ncurses.h> header file. */
 #undef HAVE_NCURSES_H
 

--- a/configure.ac
+++ b/configure.ac
@@ -457,6 +457,10 @@ AC_ARG_ENABLE([mtrace],
         [--enable-mtrace],
         [enable memory tracing])
 )
+if test "$enable_mtrace" = "yes"; then
+AC_CHECK_HEADERS([mtrace.h], ,
+    AC_MSG_ERROR([*** mtrace header file (mtrace.h) not found]))
+fi
 enable_memtrace=$enable_mtrace
 AM_CONDITIONAL(ENABLE_MEMTRACE, test "$enable_memtrace" = yes)
 

--- a/src/main.c
+++ b/src/main.c
@@ -26,7 +26,9 @@
 #include <sys/types.h>
 #include <stdio.h>
 #include <stdlib.h>
+#ifdef MEMTRACE
 #include <mcheck.h>
+#endif
 #include <stdint.h>
 #include <stdarg.h>
 #include <string.h>


### PR DESCRIPTION
Fixes #218