### PR TITLE
Add missing space before opening parenthesis

### DIFF
--- a/po/fr_FR.po
+++ b/po/fr_FR.po
@@ -119,7 +119,7 @@ msgstr "Démarrage restauration image (%s) vers périphérique (%s)\n"
 
 #: src/partclone.c:1826
 #, c-format
-msgid "Starting to back up device(%s) to device(%s)\n"
+msgid "Starting to back up device (%s) to device (%s)\n"
 msgstr "Démarrage sauvegarde périphérique (%s) vers périphérique (%s)\n"
 
 #: src/partclone.c:1828

--- a/po/partclone.pot
+++ b/po/partclone.pot
@@ -111,7 +111,7 @@ msgstr ""
 
 #: src/partclone.c:1826
 #, c-format
-msgid "Starting to back up device(%s) to device(%s)\n"
+msgid "Starting to back up device (%s) to device (%s)\n"
 msgstr ""
 
 #: src/partclone.c:1828

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -114,7 +114,7 @@ msgstr "Iniciando a restauração da imagem (%s) para dispositivo (%s)\n"
 
 #: src/partclone.c:1826
 #, c-format
-msgid "Starting to back up device(%s) to device(%s)\n"
+msgid "Starting to back up device (%s) to device (%s)\n"
 msgstr "Iniciando a backup de dispositivo (%s) para dispositivo (%s)\n"
 
 #: src/partclone.c:1828

--- a/po/ru.po
+++ b/po/ru.po
@@ -114,7 +114,7 @@ msgstr "Началось восстановление образа (%s) на у�
 
 #: src/partclone.c:1826
 #, c-format
-msgid "Starting to back up device(%s) to device(%s)\n"
+msgid "Starting to back up device (%s) to device (%s)\n"
 msgstr "Началось копирование устройства (%s) на устройство (%s)\n"
 
 #: src/partclone.c:1828

--- a/po/vi.po
+++ b/po/vi.po
@@ -114,8 +114,8 @@ msgstr "Bắt đầu phục hồi ảnh (%s) vào thiết bị (%s)\n"
 
 #: src/partclone.c:1826
 #, c-format
-msgid "Starting to back up device(%s) to device(%s)\n"
-msgstr "Bắt đầu sao lưu dự phòng thiết bị (%s) vào thiết bị(%s)\n"
+msgid "Starting to back up device (%s) to device (%s)\n"
+msgstr "Bắt đầu sao lưu dự phòng thiết bị (%s) vào thiết bị (%s)\n"
 
 #: src/partclone.c:1828
 #, c-format

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -110,7 +110,7 @@ msgstr "开始恢复 镜像 (%s) 到 装置 (%s)\n"
 
 #: src/partclone.c:1826
 #, c-format
-msgid "Starting to back up device(%s) to device(%s)\n"
+msgid "Starting to back up device (%s) to device (%s)\n"
 msgstr "开始备份 装置 (%s) 到 装置 (%s)\n"
 
 #: src/partclone.c:1828

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -112,7 +112,7 @@ msgstr "開始還原 印象檔 (%s) 到 裝置 (%s)\n"
 
 #: src/partclone.c:1826
 #, c-format
-msgid "Starting to back up device(%s) to device(%s)\n"
+msgid "Starting to back up device (%s) to device (%s)\n"
 msgstr "開始備份 裝置 (%s) 到 裝置 (%s)\n"
 
 #: src/partclone.c:1828

--- a/src/partclone.c
+++ b/src/partclone.c
@@ -1883,7 +1883,7 @@ void print_partclone_info(cmd_opt opt) {
 		else
 		    log_mesg(0, 0, 1, debug, _("Starting to restore image (%s) to device (%s)\n"), opt.source, opt.target);
 	}else if(opt.dd)
-		log_mesg(0, 0, 1, debug, _("Starting to back up device(%s) to device (%s)\n"), opt.source, opt.target);
+		log_mesg(0, 0, 1, debug, _("Starting to back up device (%s) to device (%s)\n"), opt.source, opt.target);
 	else if (opt.domain)
 		log_mesg(0, 0, 1, debug, _("Starting to map device (%s) to domain log (%s)\n"), opt.source, opt.target);
 	else if (opt.ddd)


### PR DESCRIPTION
Include my suggestion from https://github.com/Thomas-Tsai/partclone/pull/226#pullrequestreview-1435394534 to make this change consistent across the string (and apply it also to the translation files to avoid unnecessary fuzzy strings).

When writing in English (not a programming language or math), the rule is: put a space before the opening parenthesis.