### PR TITLE
Prefer bash-completion directory from pkg-config

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -485,6 +485,11 @@ AC_ARG_ENABLE([fs-test],
 AM_CONDITIONAL(ENABLE_FS_TEST, test "$enable_fs_test" = yes)
 AM_CONDITIONAL(ENABLE_FEATURE_TEST, test "$enable_feature_test" = yes)
 
+##bash-completion
+PKG_CHECK_VAR([bashcompletiondir], [bash-completion], [completionsdir], [],
+    [bashcompletiondir="${sysconfdir}/bash_completion.d"])
+AC_SUBST(bashcompletiondir)
+
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_FILES([
 	Makefile

--- a/m4/compat.m4
+++ b/m4/compat.m4
@@ -1,0 +1,24 @@
+# backwards compat with older pkg-config
+# - pull in AC_DEFUN from pkg.m4
+m4_ifndef([PKG_CHECK_VAR], [
+# PKG_CHECK_VAR(VARIABLE, MODULE, CONFIG-VARIABLE,
+# [ACTION-IF-FOUND], [ACTION-IF-NOT-FOUND])
+# -------------------------------------------
+# Retrieves the value of the pkg-config variable for the given module.
+AC_DEFUN([PKG_CHECK_VAR],
+[AC_REQUIRE([PKG_PROG_PKG_CONFIG])dnl
+AC_ARG_VAR([$1], [value of $3 for $2, overriding pkg-config])dnl
+
+_PKG_CONFIG([$1], [variable="][$3]["], [$2])
+AS_VAR_COPY([$1], [pkg_cv_][$1])
+
+AS_VAR_IF([$1], [""], [$5], [$4])dnl
+])# PKG_CHECK_VAR
+])
+
+# This hack makes PKG_CHECK_VARS from m4/pkg.m4 work on autoconf 2.63
+# (courtesy of sunnybear in https://github.com/gdnsd/gdnsd/issues/85)
+m4_ifndef([AS_VAR_COPY],
+[m4_define([AS_VAR_COPY],
+[AS_LITERAL_IF([$1[]$2], [$1=$$2], [eval $1=\$$2])])])
+## End Autoconf-2.63-Compat

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -198,7 +198,7 @@ partclone_imgfuse_LDADD+=-ldl -lcrypto ${LDADD_static}
 endif
 endif
 
-compconfdir=$(sysconfdir)/bash_completion.d
+compconfdir=@bashcompletiondir@
 compconf_DATA = partclone-prompt
 
 # Extra


### PR DESCRIPTION
As of writing, the bash-completion configuration is installed in the `$(sysconfdir)/bash_completion.d/` directory, while downstreams, such as Linux distributions, might prefer `/usr/share/bash-completion/completions/` (or even another path). For this, the pkg-config configuration file from bash-completion provides a variable being leveraged here (with fallback to the current directory).

To avoid breaking old Linux distributions with pkg-config < 0.28, some autoconf code for backwards compatibility is added, too.