### PR TITLE
Add missing return in libvmfs_version().

### DIFF
--- a/src/deplib_version.c
+++ b/src/deplib_version.c
@@ -58,7 +58,9 @@ int libvmfs_version(){
     version = "0.2.5";
 #endif
     printf("%s\n", version);
+    return 0;
 #endif
+    return 1;
 }
 
 int libntfs_version(){


### PR DESCRIPTION
libvmfs_version() return without int value.