### PR TITLE
Conditionally run the reiser4 test

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -19,9 +19,9 @@ if ENABLE_REISERFS
 TESTS += reiserfs.test
 endif
 
-#if ENABLE_REISER4
+if ENABLE_REISER4
 TESTS += reiser4.test
-#endif
+endif
 
 if ENABLE_HFSP
 TESTS += hfsplus.test


### PR DESCRIPTION
The line to add the test was uncommented a while ago, possibly intentionally, but the surrounding lines to make it conditional were not. Disclaimer: I have not actually tried to run the test.