### PR TITLE
Check for `byteswap.h` existence for `src/f2fs/f2fs_fs.h`

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -450,6 +450,9 @@ if test "$ac_cv_have_decl_isnormal" = "yes" ; then
     AC_TRY_LINK([#include <math.h>], [float f = 0.0; return isnormal(f)], [], [LIBS="$LIBS -lm"])
 fi
 
+##bswap_64()##
+AC_CHECK_HEADERS([byteswap.h])
+
 ##static linking##
 AC_ARG_ENABLE([static],
     AS_HELP_STRING(


### PR DESCRIPTION
`src/f2fs/f2fs_fs.h` uses `bswap_64()`, which is part of `byteswap.h` e.g. on glibc-based systems. The `src/f2fs/f2fs_fs.h` already knows how to handle the existence of `byteswap.h`, once there is a configure header check for it. Otherwise building on s390x fails like this:
```
f2fs/f2fs_fs.h:218:25: error: implicit declaration of function ‘bswap_64’; did you mean ‘bswap_32’? [-Wimplicit-function-declaration]
```