### PR TITLE
The BITS_TO_BYTES macro in src/bitmap.h doesn't handle integer overflow creating vulnerability

### DIFF
--- a/src/bitmap.h
+++ b/src/bitmap.h
@@ -1,10 +1,33 @@
 #include <string.h>
+#include <limits.h>
 
 #define PART_BYTES_PER_LONG ((int)sizeof(unsigned long))
 #define PART_BITS_PER_BYTE  (8)
 #define PART_BITS_PER_LONG  (PART_BYTES_PER_LONG*8)
-#define BITS_TO_BYTES(bits) (((bits)+PART_BITS_PER_BYTE-1)/PART_BITS_PER_BYTE)
-#define BITS_TO_LONGS(bits) (((bits)+PART_BITS_PER_LONG-1)/PART_BITS_PER_LONG)
+
+/*
+ * Safe conversion from bits to bytes with overflow checking.
+ * Returns 0 on overflow to indicate error (0 is not a valid bitmap size).
+ */
+static inline unsigned long long BITS_TO_BYTES(unsigned long long bits)
+{
+	/* Check for overflow: if bits > ULLONG_MAX - 7, then bits + 7 will overflow */
+	if (bits > ULLONG_MAX - (PART_BITS_PER_BYTE - 1))
+		return 0;
+	return (bits + PART_BITS_PER_BYTE - 1) / PART_BITS_PER_BYTE;
+}
+
+/*
+ * Safe conversion from bits to longs with overflow checking.
+ * Returns 0 on overflow to indicate error (0 is not a valid bitmap size).
+ */
+static inline unsigned long long BITS_TO_LONGS(unsigned long long bits)
+{
+	/* Check for overflow: if bits > ULLONG_MAX - (PART_BITS_PER_LONG-1), overflow occurs */
+	if (bits > ULLONG_MAX - (PART_BITS_PER_LONG - 1))
+		return 0;
+	return (bits + PART_BITS_PER_LONG - 1) / PART_BITS_PER_LONG;
+}
 
 static inline int
 pc_test_bit(unsigned long int nr, unsigned long *bitmap,
@@ -53,12 +76,20 @@ pc_clear_bit(unsigned long int nr, unsigned long *bitmap,
 
 static inline unsigned long* pc_alloc_bitmap(unsigned long bits)
 {
-	return (unsigned long*)calloc(PART_BYTES_PER_LONG, BITS_TO_LONGS(bits));
+	unsigned long long num_longs = BITS_TO_LONGS(bits);
+	/* Check for overflow - BITS_TO_LONGS returns 0 on overflow */
+	if (num_longs == 0 && bits != 0)
+		return NULL;
+	return (unsigned long*)calloc(PART_BYTES_PER_LONG, num_longs);
 }
 
 static inline void pc_init_bitmap(unsigned long* bitmap, char value, unsigned long bits)
 {
-	unsigned long byte_count = PART_BYTES_PER_LONG * BITS_TO_LONGS(bits);
+	unsigned long long num_longs = BITS_TO_LONGS(bits);
+	/* Check for overflow - BITS_TO_LONGS returns 0 on overflow */
+	if (num_longs == 0 && bits != 0)
+		return;
+	unsigned long byte_count = PART_BYTES_PER_LONG * num_longs;
 
 	memset(bitmap, value, byte_count);
 }

--- a/src/partclone.c
+++ b/src/partclone.c
@@ -929,6 +929,13 @@ void load_image_desc_v1(file_system_info* fs_info, image_options* img_opt,
 	fs_info->totalblock  = fs_info_v1.totalblock;
 	fs_info->usedblocks  = fs_info_v1.usedblocks;
 
+	/* Validate totalblock to prevent BITS_TO_BYTES overflow */
+	if (fs_info->totalblock > ULLONG_MAX - 7) {
+		log_mesg(0, 1, 1, opt->debug,
+			"Invalid image: totalblock value (%llu) would cause integer overflow\n",
+			(unsigned long long)fs_info->totalblock);
+	}
+
 	dev_size = fs_info->totalblock * fs_info->block_size;
 	if (fs_info->device_size != dev_size) {
 
@@ -949,6 +956,13 @@ void load_image_desc_v2(file_system_info* fs_info, image_options* img_opt,
 
 	memcpy(fs_info, &fs_info_v2, sizeof(file_system_info_v2));
 	memcpy(img_opt, &img_opt_v2, sizeof(image_options_v2));
+
+	/* Validate totalblock to prevent BITS_TO_BYTES overflow */
+	if (fs_info->totalblock > ULLONG_MAX - 7) {
+		log_mesg(0, 1, 1, opt->debug,
+			"Invalid image: totalblock value (%llu) would cause integer overflow\n",
+			(unsigned long long)fs_info->totalblock);
+	}
 }
 
 /**


### PR DESCRIPTION
When totalblock ≈ ULLONG_MAX, the calculation (totalblock + 7) wraps to 0, causing malloc(0) followed by out of bounds access.  This creates a security issue in the case of a malicious image.  Example partclone image is attached that reproduces this condition.
[bits_bytes_example.zip](https://github.com/user-attachments/files/23402271/bits_bytes_example.zip)

NOTE: You must be restoring to a block device that is non-zero. A loopback device for testing is fine.

Before:

Calculating bitmap... Please wait...
done!
File system:  EXTFS
Device size:  18446744.0 = 18446744073709551609 Blocks
Space in use:   4.1 MB = 1000 Blocks
Free Space:   18446744.0 = 18446744073709550609 Blocks
Block size:   4096 Byte
Segmentation fault (core dumped)

After:

Invalid image: totalblock value (18446744073709551609) would cause integer overflow
Partclone fail, please check /var/log/partclone.log !
