### PR TITLE
xfsclone: prevent startblock truncation to support filesystems larger than 16TB

### DIFF
--- a/src/xfsclone.c
+++ b/src/xfsclone.c
@@ -110,7 +110,7 @@ addtohist(
 
 	log_mesg(1, 0, 0, fs_opt.debug, "%s: add %8d %8d %8d\n", __FILE__, agno, agbno, len);
 	
-	start_block = (agno*mp->m_sb.sb_agblocks) + agbno;
+	start_block = ((unsigned long long)agno*mp->m_sb.sb_agblocks) + agbno;
 	set_bitmap(xfs_bitmap, start_block, len);
 
 }


### PR DESCRIPTION
Ensure 64-bit arithmetic when computing global block numbers from AG-relative addresses by casting agno to unsigned long long before multiplication. This avoids 32-bit overflow in (agno * agblocks + agbno) on large XFS filesystems,which previously caused block offsets to wrap around and corrupt the bitmap. With this fix, partclone correctly handles filesystems exceeding 16TB.