### PR TITLE
Prevent redefinition of `barrier` macro

### DIFF
--- a/src/xfs/include/platform_defs.h
+++ b/src/xfs/include/platform_defs.h
@@ -147,18 +147,20 @@ static inline size_t __ab_c_size(size_t a, size_t b, size_t c)
 #define __init
 
 #ifdef __GNUC__
-#define __return_address	__builtin_return_address(0)
+# define __return_address	__builtin_return_address(0)
 
 /*
  * Return the address of a label.  Use barrier() so that the optimizer
  * won't reorder code to refactor the error jumpouts into a single
  * return, which throws off the reported address.
  */
-#define __this_address	({ __label__ __here; __here: barrier(); &&__here; })
+# define __this_address	({ __label__ __here; __here: barrier(); &&__here; })
 /* Optimization barrier */
 
 /* The "volatile" is due to gcc bugs */
-#define barrier() __asm__ __volatile__("": : :"memory")
+# ifndef barrier
+#  define barrier() __asm__ __volatile__("": : :"memory")
+# endif
 #endif
 
 /* Optimization barrier */


### PR DESCRIPTION
The `barrier` macro may already be defined by system-provided headers (in my case, that was _liburcu_ — used for _xfs_ exactly), and in a more architecture-specific way than a generic `__asm__ ("" : : : "memory")`. So it should not be redefined uncoditionally.

Also fixed the indentation of nested preprocessor lines within the `__GNUC__` block.