### PR TITLE
Revert bash-completion dir datadir -> sysconfdir from January 2026

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -545,7 +545,7 @@ AM_CONDITIONAL(ENABLE_FEATURE_TEST, test "$enable_feature_test" = yes)
 
 ##bash-completion
 PKG_CHECK_VAR([bashcompletiondir], [bash-completion], [completionsdir], [],
-    [bashcompletiondir='${datadir}/bash-completion/completions'])
+    [bashcompletiondir="${sysconfdir}/bash_completion.d"])
 AC_SUBST(bashcompletiondir)
 
 AC_CONFIG_HEADERS([config.h])


### PR DESCRIPTION
Hi Thomas,

For the upcoming version of Rescuezilla, I’m incrementing partclone from v0.3.40 (2025-11-25) to the latest tagged version v0.3.47 (2026-03-11).

When testing this, I hit an issue in my workflow: "cannot create regular file '/usr/local/share/bash-completion/completions/partclone-completion': No such file or directory"/

This happens when I try to create a DEB package with the somewhat popular `checkinstall` tool, which is an approach I have been using to create a DEB for some time.

# Reproduction

Build using eg:
```
./configure --enable-ncursesw --enable-static --enable-extfs --enable-reiser4 --enable-ntfs --enable-fat --enable-exfat --enable-hfsp --enable-apfs --enable-btrfs --enable-minix --enable-f2fs --enable-nilfs2
make
```
Then run `checkinstall --install=no --pkgname partclone --pkgversion 0.3.47 --pkgrelease 1 --maintainer 'test@example.com' -D --default  make install` to create a deb.

I see the following output in my Ubuntu 24.04 Docker container

```
libtool: install: /usr/bin/install -c partclone.btrfs /usr/local/sbin/partclone.btrfs
libtool: install: /usr/bin/install -c partclone.minix /usr/local/sbin/partclone.minix
make  install-exec-hook
make[3]: Entering directory '/home/rescuezilla/build/.amd64/partclone-latest/src'
ln -s -f partclone.extfs /usr/local/sbin/partclone.ext2
ln -s -f partclone.extfs /usr/local/sbin/partclone.ext3
ln -s -f partclone.extfs /usr/local/sbin/partclone.ext4
ln -s -f partclone.extfs /usr/local/sbin/partclone.ext4dev
ln -s -f partclone.hfsp /usr/local/sbin/partclone.hfs+
ln -s -f partclone.hfsp /usr/local/sbin/partclone.hfsplus
ln -s -f partclone.ntfsfixboot /usr/local/sbin/partclone.ntfsreloc
ln -s -f partclone.fat /usr/local/sbin/partclone.fat12
ln -s -f partclone.fat /usr/local/sbin/partclone.fat16
ln -s -f partclone.fat /usr/local/sbin/partclone.fat32
ln -s -f partclone.fat /usr/local/sbin/partclone.vfat
make[3]: Leaving directory '/home/rescuezilla/build/.amd64/partclone-latest/src'
 /usr/bin/mkdir -p '/usr/local/share/bash-completion/completions'
 /usr/bin/install -c -m 644 partclone-completion '/usr/local/share/bash-completion/completions'
/usr/bin/install: cannot create regular file '/usr/local/share/bash-completion/completions/partclone-completion': No such file or directory
make[2]: *** [Makefile:5729: install-bashcompletionDATA] Error 1
make[2]: Leaving directory '/home/rescuezilla/build/.amd64/partclone-latest/src'
make[1]: *** [Makefile:5846: install-am] Error 2
make[1]: Leaving directory '/home/rescuezilla/build/.amd64/partclone-latest/src'
make: *** [Makefile:482: install-recursive] Error 1
```

# Workaround

I have tracked the issue down to being introduced by the [commit `update for bash completion` from January 2026](https://github.com/Thomas-Tsai/partclone/commit/005a76958568d6df8b4d9dbd4c8fdc3391c8b461#diff-49473dca262eeab3b4a43002adb08b4db31020d190caaad1594b47f1d5daa810R536).

Since bash-completions aren't required for the Rescuezilla live environment and its graphical-user interface, I am happy to simply revert the offending line.

There isn't much context in the original commit "update for bash completion", but if there's a better solution, please let me know!