### PR TITLE
fix(hfsplus): write alternate volume header to end of larger target

### DIFF
--- a/src/hfsplusclone.c
+++ b/src/hfsplusclone.c
@@ -23,6 +23,7 @@
 #include <unistd.h>
 #include <sys/types.h>
 #include <linux/types.h>
+#include <limits.h>
 
 #include "partclone.h"
 #include "hfsplusclone.h"
@@ -372,4 +373,131 @@ void read_super_blocks(char* device, file_system_info* fs_info)
     print_fork_data(&sb.attributesFile);
     print_fork_data(&sb.startupFile);
     fs_close();
+}
+
+/// HFS+ maintains an alternate volume header in the last 1024 bytes of the
+/// volume. The Linux hfsplus kernel driver validates both the primary VH
+/// (at offset 1024) and the alternate VH (at target_size - 1024) on mount.
+/// When the target device is larger than the source, the alternate VH was
+/// written at source_size - 1024 by the block copy loop, but the kernel
+/// looks for it at target_size - 1024. This hook copies it to the correct
+/// location so the target remains mountable.
+int post_clone_fixup(int* dfw, file_system_info fs_info, cmd_opt opt)
+{
+    struct stat st;
+    unsigned long long target_size, src_size;
+    off_t src_alt_offset, dst_alt_offset;
+    char alt_vh_buf[1024];
+    ssize_t r_size, w_size;
+    int rfd = -1;
+    int ret_val = 1;
+
+    // Only relevant for block device targets (not image files / stdout)
+    if (dfw == NULL || *dfw < 0)
+        return 0;
+    if (fstat(*dfw, &st) != 0) {
+        log_mesg(1, 0, 0, opt.debug, "%s: post_clone_fixup: fstat failed: %s\n", __FILE__, strerror(errno));
+        return 1;
+    }
+    if (!S_ISBLK(st.st_mode))
+        return 0;
+
+    target_size = get_partition_size(dfw);
+    if (target_size == 0) {
+        log_mesg(1, 0, 0, opt.debug, "%s: post_clone_fixup: target_size is 0, skipping\n", __FILE__);
+        return 0;
+    }
+
+    src_size = fs_info.device_size;
+
+    // If target is not larger than source, the alt VH is already in place
+    if (target_size <= src_size) {
+        log_mesg(2, 0, 0, opt.debug, "%s: post_clone_fixup: target (%llu) <= source (%llu), no fixup needed\n",
+                 __FILE__, target_size, src_size);
+        return 0;
+    }
+
+    // HFS+ alternate VH is the last 1024 bytes of the volume
+    if (src_size < 1024) {
+        log_mesg(1, 0, 0, opt.debug, "%s: post_clone_fixup: source device_size (%llu) < 1024, cannot read alt VH\n",
+                 __FILE__, src_size);
+        return 1;
+    }
+
+    src_alt_offset = (off_t)(src_size - 1024);
+    dst_alt_offset = (off_t)(target_size - 1024);
+
+    log_mesg(1, 0, 0, opt.debug, "%s: post_clone_fixup: copying HFS+ alt VH from offset %lld to %lld (target_size=%llu, src_size=%llu)\n",
+             __FILE__, (long long)src_alt_offset, (long long)dst_alt_offset, target_size, src_size);
+
+    // The target fd may have been opened O_WRONLY (e.g. dd/restore paths),
+    // so we cannot read from it directly. Re-open the same block device
+    // O_RDONLY just for reading back the alt VH that the block copy loop
+    // already wrote at src_size - 1024.
+    // Resolve the target device path from the open fd via /proc/self/fd/<fd>
+    {
+        char proc_path[64];
+        char dev_path[PATH_MAX];
+        ssize_t link_len;
+        snprintf(proc_path, sizeof(proc_path), "/proc/self/fd/%d", *dfw);
+        link_len = readlink(proc_path, dev_path, sizeof(dev_path) - 1);
+        if (link_len < 0) {
+            log_mesg(0, 0, 1, opt.debug, "%s: post_clone_fixup: cannot resolve target fd path via %s: %s\n",
+                     __FILE__, proc_path, strerror(errno));
+            return 1;
+        }
+        dev_path[link_len] = '\0';
+
+        rfd = open(dev_path, O_RDONLY);
+        if (rfd < 0) {
+            log_mesg(0, 0, 1, opt.debug, "%s: post_clone_fixup: cannot re-open target %s O_RDONLY for reading: %s\n",
+                     __FILE__, dev_path, strerror(errno));
+            return 1;
+        }
+    }
+
+    // Read the alt VH from where the block copy loop wrote it (src_size - 1024)
+    if (lseek(rfd, src_alt_offset, SEEK_SET) != src_alt_offset) {
+        log_mesg(0, 0, 1, opt.debug, "%s: post_clone_fixup: seek to src alt VH offset %lld failed: %s\n",
+                 __FILE__, (long long)src_alt_offset, strerror(errno));
+        goto out;
+    }
+    r_size = read(rfd, alt_vh_buf, sizeof(alt_vh_buf));
+    if (r_size != (ssize_t)sizeof(alt_vh_buf)) {
+        log_mesg(0, 0, 1, opt.debug, "%s: post_clone_fixup: read alt VH failed (read %zd, expected %zu): %s\n",
+                 __FILE__, r_size, sizeof(alt_vh_buf), strerror(errno));
+        goto out;
+    }
+
+    // Sanity check: the alt VH should have a valid HFS+ signature
+    {
+        UInt16 sig = be16toh(((struct HFSPlusVolumeHeader*)alt_vh_buf)->signature);
+        if (sig != HFSPlusSignature && sig != HFSXSignature) {
+            log_mesg(0, 0, 1, opt.debug, "%s: post_clone_fixup: alt VH at offset %lld has invalid signature 0x%04x, skipping (source may not be HFS+ at this offset)\n",
+                     __FILE__, (long long)src_alt_offset, sig);
+            goto out;
+        }
+    }
+
+    // Write the alt VH to the end of the (larger) target device via the
+    // original writable fd.
+    if (lseek(*dfw, dst_alt_offset, SEEK_SET) != dst_alt_offset) {
+        log_mesg(0, 0, 1, opt.debug, "%s: post_clone_fixup: seek to dst alt VH offset %lld failed: %s\n",
+                 __FILE__, (long long)dst_alt_offset, strerror(errno));
+        goto out;
+    }
+    w_size = write(*dfw, alt_vh_buf, sizeof(alt_vh_buf));
+    if (w_size != (ssize_t)sizeof(alt_vh_buf)) {
+        log_mesg(0, 0, 1, opt.debug, "%s: post_clone_fixup: write alt VH failed (wrote %zd, expected %zu): %s\n",
+                 __FILE__, w_size, sizeof(alt_vh_buf), strerror(errno));
+        goto out;
+    }
+
+    log_mesg(1, 0, 0, opt.debug, "%s: post_clone_fixup: HFS+ alt VH copied to target end successfully\n", __FILE__);
+    ret_val = 0;
+
+out:
+    if (rfd >= 0)
+        close(rfd);
+    return ret_val;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -1206,6 +1206,19 @@ int main(int argc, char **argv) {
 #endif
 	print_finish_info(opt);
 
+#ifndef CHKIMG
+	/// Filesystem-specific post-clone fixups (e.g. HFS+ alternate volume
+	/// header must be copied to the end of a larger target device).
+	/// Only meaningful when writing to a block device (dd / restore / ddd);
+	/// the default no-op returns 0 for image-file targets and clone mode.
+	if (dfw != -1) {
+		if (post_clone_fixup(&dfw, fs_info, opt) != 0)
+			log_mesg(0, 0, 1, debug, "%s: post_clone_fixup reported a non-fatal error\n", __func__);
+		/// Make sure the fixup bytes are durable before close.
+		sync_data(dfw, &opt);
+	}
+#endif
+
 	/// close source
 	close(dfr);
 	/// close target

--- a/src/partclone.c
+++ b/src/partclone.c
@@ -1279,6 +1279,23 @@ int check_size(int* ret, unsigned long long size) {
 
 }
 
+/**
+ * Default no-op implementation of post_clone_fixup.
+ *
+ * Filesystem modules (e.g. hfsplusclone.c) may override this weak symbol to
+ * perform filesystem-specific fixups after the block copy loop finishes, such
+ * as writing an alternate superblock to the end of a larger target device.
+ *
+ * See the docstring in partclone.h for full semantics.
+ */
+__attribute__((weak)) int post_clone_fixup(int* dfw, file_system_info fs_info, cmd_opt opt)
+{
+	(void)dfw;
+	(void)fs_info;
+	(void)opt;
+	return 0;
+}
+
 /// remove DIR, copy from http://stackoverflow.com/questions/2256945/removing-a-non-empty-directory-programmatically-in-c-or-c
 int remove_directory(const char *path)
 {

--- a/src/partclone.h
+++ b/src/partclone.h
@@ -374,3 +374,23 @@ extern void init_bt_info(bt_info_t * bt, char *target,
 
 extern void update_bt_info(bt_info_t * bt, unsigned long long offset,
 			   char *buffer, unsigned long long length);
+
+/**
+ * post_clone_fixup - filesystem-specific fixups after a device-to-device or
+ * restore operation has finished writing all data blocks.
+ *
+ * Some filesystems (e.g. HFS+) keep a secondary/alternate superblock at the
+ * very end of the volume. When the target device is larger than the source,
+ * the kernel looks for this alternate superblock at target_size - 1024, which
+ * was never written by the block copy loop. This hook lets each filesystem
+ * copy any trailing metadata to the correct location on the target.
+ *
+ * Default implementation is a no-op (defined as a weak symbol in partclone.c).
+ * Filesystem modules may override it.
+ *
+ * @dfw       file descriptor of the target (already open, before close_target)
+ * @fs_info   filesystem info (block_size, device_size, totalblock, fs magic)
+ * @opt       command options (debug, etc.)
+ * @return    0 on success, non-zero on failure (logged but non-fatal)
+ */
+extern int post_clone_fixup(int* dfw, file_system_info fs_info, cmd_opt opt);


### PR DESCRIPTION
fix(hfsplus): write alternate volume header to end of larger target device

HFS+ maintains an alternate volume header in the last 1024 bytes of the
volume. The Linux hfsplus kernel driver validates both the primary VH
(at offset 1024) and the alternate VH (at target_size - 1024) on mount.

When the target device is larger than the source, the block copy loop
writes the alt-VH at source_size - 1024, but the kernel looks for it at
target_size - 1024 — which was never written. This causes mount to fail
with "hfsplus: invalid secondary volume header".

Add a post_clone_fixup() hook (weak no-op default in partclone.c,
overridden by hfsplusclone.c) that copies the alt-VH to the correct
location on the target after the block copy loop finishes, for both
device-to-device (-b) and restore (-r) paths. Non-HFS+ filesystems are
unaffected (the weak default returns 0).

Verified on self-hosted CI: 15GB source / 36GB target, full
data_clone_restore_test hfsplus passes (md5 verified both directions).